### PR TITLE
Fixing errors

### DIFF
--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -335,7 +335,7 @@ estimate_infections <- function(reported_cases, family = "negbin",
   
   if (estimate_rt) {
     out$initial_infections <- rnorm(mean_shift, mean = 0, sd = 0.1)
-    out$R <- array(rgamma(n = 1, shape = (rt_prior$mean / rt_prior$sd)^2, 
+    out$initial_R <- array(rgamma(n = 1, shape = (rt_prior$mean / rt_prior$sd)^2, 
                           scale = (rt_prior$sd^2) / rt_prior$mean))
     out$gt_mean <- array(truncnorm::rtruncnorm(1, a = 0, mean = generation_time$mean,  
                                                sd = generation_time$mean_sd))

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -111,7 +111,8 @@ transformed data{
    // basis functions
    // see here for details: https://arxiv.org/pdf/2004.11408.pdf
    for (m in 1:M){ 
-     PHI[,m] = phi_SE(L, m, (estimate_r > 0 ? time[1:(stationary > 0 ? rt : rt - 1)] : inf_time)); 
+     // PHI[,m] = phi_SE(L, m, (estimate_r > 0 ? time[1:(stationary > 0 ? rt : rt - 1)] : inf_time)); 
+     PHI[, m] = phi_SE(L, m, (estimate_r > 0 ? time[1:rt] : inf_time));
     }
 }
 parameters{


### PR DESCRIPTION
Fixed an error where neg_binomial_lpmf was being given a nan value. E…rror was occurring because the dimensions of PHI for non-stationary GPs was being set as rt - 1 but it is later multiplied with noise that has dimension rt. This gave a nan for the final value.

Error looked like this:
` [1] "Chain 2: Informational Message: The current Metropolis proposal is about to be rejected because of the following issue:"                        
 [2] "Chain 2: Exception: neg_binomial_2_lpmf: Location parameter[1] is nan, but must be > 0!  (in 'model_estimate_infections' at line 280)"          
 [3] "Chain 2: If this warning occurs sporadically, such as for highly constrained variable types like covariance matrices, then the sampler is fine,"
 [4] "Chain 2: but if this warning occurs often then your model may be either severely ill-conditioned or misspecified."  `

Fixed another error where the function that generates initial values passed in values for `R` instead of `initial_R`. I suspect that stan was generating its own initial values for `initial_R` that did not respect the lower bound of 0 and caused the error that blew up the `poisson_rng` calls in generated functions.

Chains seem to run error-free now.