### PR TITLE
Improve plotting uncertainty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * README updated by @kathsherratt
 * Logging added by @joeHickson
 * Updated plotting to be limited to a scaling of reported data (prevents upper CIs from skewing the plot).
+* Added uncertainty plot bounds to control y axis on plots for clarity purposes.
 
 # EpiNow2 1.0.0
 

--- a/R/epinow.R
+++ b/R/epinow.R
@@ -336,6 +336,7 @@ regional_epinow <- function(reported_cases,
                             region_scale = "Region",
                             all_regions_summary = TRUE,
                             return_estimates = TRUE,
+                            max_plot = 10,
                             ...) {
     
   ## Set input to data.table
@@ -425,7 +426,8 @@ regional_epinow <- function(reported_cases,
                                 summary_dir = summary_dir,
                                 reported_cases = reported_cases,
                                 region_scale = region_scale,
-                                all_regions = all_regions_summary)
+                                all_regions = all_regions_summary,
+                                max_plot = max_plot)
 
     if (!is.null(summary_out[[2]])) {
       futile.logger::flog.info("Errors caught whilst generating summary statistics: ")

--- a/R/plot.R
+++ b/R/plot.R
@@ -148,6 +148,7 @@ plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
 #' @param summary_results A data.able as returned by `summarise_results` (the `data` object).
 #' @param x_lab A character string giving the label for the x axis, defaults to region.
 #' @param log_cases Logical, should cases be shown on a logged scale. Defaults to `FALSE`
+#' @param max_cases Numeric, no default. The maximum number of cases to plot. 
 #' @return A `ggplot2` object
 #' @export
 #' @importFrom ggplot2 ggplot aes geom_linerange geom_hline facet_wrap theme guides labs expand_limits guide_legend element_blank scale_color_manual .data coord_cartesian scale_y_continuous
@@ -155,7 +156,8 @@ plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
 #' @importFrom cowplot theme_cowplot panel_border
 #' @importFrom patchwork plot_layout
 #' @importFrom data.table setDT
-plot_summary <- function(summary_results, x_lab = "Region", log_cases = FALSE) {
+plot_summary <- function(summary_results, x_lab = "Region", log_cases = FALSE,
+                         max_cases) {
   
   ## Set input to data.table
   summary_results <- data.table::setDT(summary_results)
@@ -186,6 +188,11 @@ plot_summary <- function(summary_results, x_lab = "Region", log_cases = FALSE) {
     ggplot2::theme(axis.title.x = ggplot2::element_blank(),
                    axis.text.x = ggplot2::element_blank()) +
     ggplot2::theme(legend.position = "none")
+  
+  if (!missing(max_cases)) {
+    cases_plot <- cases_plot + 
+      ggplot2::coord_cartesian(ylim = c(0, max_cases))
+  }
   
   if (log_cases) {
     cases_plot <- cases_plot +

--- a/R/plot.R
+++ b/R/plot.R
@@ -119,7 +119,7 @@ plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
     ggplot2::geom_vline(xintercept = estimate[type == "Estimate based on partial data"][date == max(date)]$date,
                         linetype = 2) +
     ggplot2::geom_ribbon(ggplot2::aes(ymin = bottom, ymax = top), 
-                         alpha = 0.25, size = 0.2) +
+                         alpha = 0.25, size = 0.05) +
     ggplot2::geom_ribbon(ggplot2::aes(ymin = lower, ymax = upper, col = NULL), 
                          alpha = 0.5) +
     cowplot::theme_cowplot() +

--- a/R/plot.R
+++ b/R/plot.R
@@ -7,13 +7,15 @@
 #' @param hline Numeric, if supplied gives the horizontal intercept for a indicator line.
 #' @param obs_as_col Logical, defaults to `TRUE`. Should observed data, if supplied, be plotted using columns or 
 #' as points (linked using a line).
-#'
+#' @param max_plot Numeric, defaults to 10. A multiplicative upper bound on the number of cases shown on the plot. Based
+#' on the maximum number of reported cases. 
 #' @return A `ggplot2` object
 #' @export
 #' @importFrom ggplot2 ggplot aes geom_col geom_line geom_point geom_vline geom_hline geom_ribbon scale_y_continuous
 #' @importFrom scales comma
 #' @importFrom cowplot theme_cowplot
 #' @importFrom data.table setDT
+#' @importFrom purrr map
 #' @examples
 #' \donttest{
 #' ## Define example cases
@@ -49,12 +51,12 @@
 #' ## Plot infections
 #' plot_estimates(
 #'   estimate = out$summarised[variable == "infections"],
-#'   reported = cases, 
+#'   reported = cases,
 #'   ylab = "Cases")
 #' 
 #' ## Plot reported cases estimated via Rt
 #' plot_estimates(estimate = out$summarised[variable == "reported_cases"],
-#'                reported = cases, 
+#'                reported = cases,
 #'                ylab = "Cases")
 #'                
 #'## Plot Rt estimates
@@ -64,7 +66,7 @@
 #' 
 #' }
 plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
-                           obs_as_col = TRUE) {
+                           obs_as_col = TRUE, max_plot = 10) {
   
   ## Convert input to data.table
   estimate <- data.table::setDT(estimate)
@@ -79,6 +81,15 @@ plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
   }
   
   estimate <- estimate[, type := to_sentence(type)]
+  
+  ## Scale plot values based on reported cases
+  if (!missing(reported)) {
+    max_cases_to_plot <- round(max(reported$confirm, na.rm = TRUE) * max_plot, 0)
+    
+    estimate <- estimate[, lapply(.SD, function(var){ifelse(var > max_cases_to_plot, max_cases_to_plot, var)}),
+                         by = c("type", "date"), 
+                          .SDcols=c("upper", "lower", "bottom", "top")] 
+  }
   
   ## Initialise plot
   plot <- ggplot2::ggplot(estimate, ggplot2::aes(x = date, col = type, fill = type))

--- a/R/report.R
+++ b/R/report.R
@@ -243,7 +243,7 @@ report_summary <- function(summarised_estimates,
 #'                      
 #' ## Plot infections
 #' plots <- report_plots(summarised_estimates = out$summarised,
-#'                       reported = cases, max_plot = 2)
+#'                       reported = cases)
 #'                       
 #' plots
 #' }

--- a/R/report.R
+++ b/R/report.R
@@ -243,7 +243,7 @@ report_summary <- function(summarised_estimates,
 #'                      
 #' ## Plot infections
 #' plots <- report_plots(summarised_estimates = out$summarised,
-#'                       reported = cases)
+#'                       reported = cases, max_plot = 2)
 #'                       
 #' plots
 #' }

--- a/R/report.R
+++ b/R/report.R
@@ -248,7 +248,7 @@ report_summary <- function(summarised_estimates,
 #' plots
 #' }
 report_plots <- function(summarised_estimates, reported,
-                         target_folder) {
+                         target_folder, max_plot = 10) {
   
   ## set input to data.table
   summarised_estimates <- data.table::setDT(summarised_estimates)
@@ -262,7 +262,8 @@ report_plots <- function(summarised_estimates, reported,
 
 infections <- plot_estimates(estimate = summarised_estimates[variable == "infections"],
                              reported = reported,
-                             ylab = "Cases by \n date of infection")
+                             ylab = "Cases by \n date of infection",
+                             max_plot = max_plot)
   
 
 if (!is.null(target_folder)) {
@@ -279,7 +280,8 @@ if (!is.null(target_folder)) {
 # Cases by report ---------------------------------------------------------
 
 reports <- plot_estimates(estimate = summarised_estimates[variable == "reported_cases"],
-                          reported = reported, ylab = "Cases by \n date of report")
+                          reported = reported, ylab = "Cases by \n date of report",
+                          max_plot = max_plot)
 
 if (!is.null(target_folder)) {
   suppressWarnings(

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -181,7 +181,8 @@ regional_summary <- function(regional_output,
                              target_date,
                              region_scale = "Region",
                              all_regions = TRUE,
-                             return_summary = TRUE) {
+                             return_summary = TRUE, 
+                             max_plot = 10) {
    
   reported_cases <- data.table::setDT(reported_cases)
   
@@ -301,11 +302,12 @@ regional_summary <- function(regional_output,
           .SD[date >= (max(date, na.rm = TRUE) - lubridate::days(7))],by = "region"]
   regions_with_most_reports <- regions_with_most_reports[, .(confirm = sum(confirm, na.rm = TRUE)), by = "region"]
   regions_with_most_reports <-  data.table::setorderv(regions_with_most_reports, cols = "confirm", order = -1)
-  regions_with_most_reports <- regions_with_most_reports$region[1:6]
+  regions_with_most_reports <- regions_with_most_reports[1:6][!is.na(region)]$region
   
   high_plots <- report_plots(
     summarised_estimates = results$estimates$summarised[region %in% regions_with_most_reports], 
-    reported = reported_cases[region %in% regions_with_most_reports]
+    reported = reported_cases[region %in% regions_with_most_reports],
+    max_plot = max_plot
   )
   
   high_plots$summary <- NULL
@@ -338,7 +340,8 @@ regional_summary <- function(regional_output,
                             ifelse(length(regions) > 120, 8, 5), 3)
     
     plots <- report_plots(summarised_estimates = results$estimates$summarised, 
-                          reported = reported_cases)
+                          reported = reported_cases,
+                          max_plot = max_plot)
     
     plots$summary <- NULL
     plots <- purrr::map(plots,

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -63,7 +63,7 @@ summarise_results <- function(regions,
   numeric_estimates  <- data.table::copy(estimates)[measure %in% c("New confirmed cases by infection date",
                                                     "Effective reproduction no.")][,
                                            .(
-                                             point = numeric_estimates[[1]]$point,
+                                             point = numeric_estimate[[1]]$point,
                                              lower = numeric_estimate[[1]]$lower,
                                              upper =numeric_estimate[[1]]$upper,
                                              mid_lower = numeric_estimate[[1]]$mid_lower,
@@ -182,7 +182,7 @@ regional_summary <- function(regional_output,
                              region_scale = "Region",
                              all_regions = TRUE,
                              return_summary = TRUE) {
-  
+   
   reported_cases <- data.table::setDT(reported_cases)
   
   if (missing(summary_dir) & !return_summary) {

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -296,10 +296,16 @@ regional_summary <- function(regional_output,
     )
   }
   
+  ## Extract regions with highest number of reported cases in the last week
+  regions_with_most_reports <- data.table::copy(reported_cases)[, 
+          .SD[date >= (max(date, na.rm = TRUE) - lubridate::days(7))],by = "region"]
+  regions_with_most_reports <- regions_with_most_reports[, .(confirm = sum(confirm, na.rm = TRUE)), by = "region"]
+  regions_with_most_reports <-  data.table::setorderv(regions_with_most_reports, cols = "confirm", order = -1)
+  regions_with_most_reports <- regions_with_most_reports$region[1:6]
   
   high_plots <- report_plots(
-    summarised_estimates = results$estimates$summarised[region %in% summarised_results$regions_by_inc[1:6]], 
-    reported = reported_cases[region %in% summarised_results$regions_by_inc[1:6]]
+    summarised_estimates = results$estimates$summarised[region %in% regions_with_most_reports], 
+    reported = reported_cases[region %in% regions_with_most_reports]
   )
   
   high_plots$summary <- NULL

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -280,11 +280,13 @@ regional_summary <- function(regional_output,
   log_cases <- (max(summarised_results$data[metric %in% "New confirmed cases by infection date"]$upper, na.rm = TRUE) / 
              min(summarised_results$data[metric %in% "New confirmed cases by infection date"]$lower, na.rm = TRUE)) > 1000
 
+  max_reported_cases <- round(max(reported_cases$confirm, na.rm = TRUE) * max_plot, 0)
   
   ## Summarise cases and Rts
   summary_plot <- EpiNow2::plot_summary(summarised_results$data,
                                         x_lab = region_scale, 
-                                        log_cases = log_cases)
+                                        log_cases = log_cases,
+                                        max_cases = max_reported_cases)
   
   if (!is.null(summary_dir)) {
     suppressWarnings(

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -11,4 +11,4 @@
 * GNU make is a SystemRequirement
 * Suggests or Enhances not in mainstream repositories: EpiSoon (available using Additional_repositories from https://epiforecasts.io/drat/)
 * Dropped usage of \dontrun
-* All data included in the package are needed for downstream users that require documentation. The example_confirmed file provides a documented example dataset of what input is supported. Unsure of what further action to take to resolve this issue without additional guidance. 
+* All data included in the package are needed for downstream users and require documentation, which seems impossible to achieve if the files are in inst/extdata. Similarly, the example_confirmed file provides a documented example dataset of what input is supported. We’re very happy to change things but are unsure of what further action to take to resolve this issue without additional guidance.

--- a/inst/templates/_all-region-summary.Rmd
+++ b/inst/templates/_all-region-summary.Rmd
@@ -16,7 +16,7 @@ knitr::include_graphics(here::here(summary_path, "rt_plot.png"))
 knitr::include_graphics(here::here(summary_path, "infections_plot.png"))
 ```
 
-`r paste0("*Figure ",  fig_start + 5, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  fig_start + 5, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 `r paste0("### Confirmed ",  case_def, "s and their estimated date of report in all regions")`
 
@@ -25,7 +25,7 @@ knitr::include_graphics(here::here(summary_path, "infections_plot.png"))
 knitr::include_graphics(here::here(summary_path, "reported_cases_plot.png"))
 ```
 
-`r paste0("*Figure ",  fig_start + 6, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of report (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  fig_start + 6, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of report (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in all regions. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 
 

--- a/inst/templates/_region-report.Rmd
+++ b/inst/templates/_region-report.Rmd
@@ -46,7 +46,7 @@ knitr::include_graphics(here::here(file.path(region_path, region, "latest/summar
 ```
 
 <br>
-`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed ",  case_def, "s by date of report (bars) and their estimated date of report. B.) Confirmed ",  case_def, "s by date of report (bars) and their estimated date of infection. C.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ",  summary_figures + 1 + (index - 1) * 2, ": A.) Confirmed ",  case_def, "s by date of report (bars) and their estimated date of report. B.) Confirmed ",  case_def, "s by date of report (bars) and their estimated date of infection. C.) Time-varying estimate of the effective reproduction number. Light ribbon = 90% credible interval; dark ribbon = the 50% credible interval. Estimates from existing data are shown up to the ", latest_date, ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""),  ". Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 
 

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -43,7 +43,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "summary_plot.png")))
 ```
 
 <br>
-`r paste0("*Figure ", fig_start, ": Confirmed ", case_def, "s with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed ",  case_def, "s and shaded based on the expected change in daily confirmed" , case_def,  "s. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination.*")`
+`r paste0("*Figure ", fig_start, ": Confirmed ", case_def, "s with date of infection on the ", latest_date, " and the time-varying estimate of the effective reproduction number (light bar = 90% credible interval; dark bar = the 50% credible interval.). Regions are ordered by the number of expected daily confirmed ",  case_def, "s and shaded based on the expected change in daily confirmed" , case_def,  "s. The horizontal dotted line indicates the target value of 1 for the effective reproduction no. required for control and a single case required for elimination. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 `r paste0("### Reproduction numbers over time in the six regions expected to have the most new confirmed ",  case_def, "s")`
 
@@ -61,7 +61,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "high_infections_plot
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 2, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def, "s.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ".  Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 2, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of infection (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def, "s.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ".  Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 `r paste0("### Confirmed ",  case_def, "s and their estimated date of report in the six regions expected to have the most new confirmed ", case_def, "s")`
 
@@ -70,7 +70,7 @@ knitr::include_graphics(here::here(file.path(summary_path, "high_reported_cases_
 ```
 
 <br>
-`r paste0("*Figure ", fig_start + 3, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of report (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def, "s.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ".  Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation.*")`
+`r paste0("*Figure ", fig_start + 3, ": Confirmed ", case_def,  "s by date of report (bars) and their estimated date of report (light ribbon = 90% credible interval; dark ribbon = the 50% credible interval) in the regions expected to have the highest number of new confirmed ", case_def, "s.  Estimates from existing data are shown up to the ", latest_date,  ifelse(report_forecast, " from when forecasts are shown. These should be considered indicative only", ""), ".  Estimates based on partial data have been adjusted for right truncation of infections. The vertical dashed line indicates the date of report generation. Uncertainty has been curtailed to a maximum of ten times the maximum number of reported cases for plotting purposes.*")`
 
 
 ```{r}


### PR DESCRIPTION
* Add max plot scaling to `plot_estimates`
* Added max cases to plot to `plot_summary`
* Added arguments to control this functionality (defaulting to 10 maximum reported cases) to all upper level functions
* Updated ordering of summary plots to show those with most reported cases in the last week rather than be based on estimated cases.
* Added additional information around these changes to the markdown templates.