### PR TITLE
fix discretised delay distributions

### DIFF
--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -195,7 +195,7 @@ transformed parameters {
     vector[max_delay[s]] rev_delay = rep_vector(1e-5, max_delay[s]);
     for (j in 1:(max_delay[s])) {
       rev_delay[j] +=
-        discretised_lognormal_pmf(max_delay[s] - j + 1, delay_mean[s], delay_sd[s], max_delay[s]);
+        discretised_lognormal_pmf(max_delay[s] - j, delay_mean[s], delay_sd[s], max_delay[s]);
     }
      if (s == 1) {
        reports_hold = convolve(infections, rev_delay);

--- a/inst/stan/functions/discretised_gamma_pmf.stan
+++ b/inst/stan/functions/discretised_gamma_pmf.stan
@@ -10,7 +10,7 @@
     alpha = is_inf(alpha) ? 1e8 : alpha;
     beta = is_inf(beta) ? 1e8 : beta; 
     return((gamma_cdf(y + 1, alpha, beta) - gamma_cdf(y, alpha, beta)) / 
-    (gamma_cdf(max_val, alpha, beta) - gamma_cdf(1, alpha, beta)));
+    (gamma_cdf(max_val + 1, alpha, beta) - gamma_cdf(1, alpha, beta)));
   }
   
   

--- a/inst/stan/functions/discretised_lognormal_pmf.stan
+++ b/inst/stan/functions/discretised_lognormal_pmf.stan
@@ -1,8 +1,11 @@
   // discretised truncated lognormal pmf
   real discretised_lognormal_pmf(int y, real mu, real sigma, int max_val) {
-    real adj_y = y + 1e-5;
-    return((normal_cdf((log(adj_y + 1) - mu) / sigma, 0.0, 1.0) - normal_cdf((log(adj_y) - mu) / sigma, 0.0, 1.0)) / 
-            normal_cdf((log(max_val) - mu) / sigma, 0.0, 1.0));
+    real small = 1e-5;
+    real adj_y = y + small;
+    return((normal_cdf((log(adj_y + 1) - mu) / sigma, 0.0, 1.0) -
+            normal_cdf((log(adj_y) - mu) / sigma, 0.0, 1.0)) /
+           (normal_cdf((log(max_val + 1 + small) - mu) / sigma, 0.0, 1.0) -
+            normal_cdf((log(1 + small) - mu) / sigma, 0.0, 1.0)));
   }
   
   

--- a/inst/stan/functions/discretised_lognormal_pmf.stan
+++ b/inst/stan/functions/discretised_lognormal_pmf.stan
@@ -4,8 +4,8 @@
     real adj_y = y + small;
     return((normal_cdf((log(adj_y + 1) - mu) / sigma, 0.0, 1.0) -
             normal_cdf((log(adj_y) - mu) / sigma, 0.0, 1.0)) /
-           (normal_cdf((log(max_val + 1 + small) - mu) / sigma, 0.0, 1.0) -
-            normal_cdf((log(1 + small) - mu) / sigma, 0.0, 1.0)));
+           (normal_cdf((log(max_val + small) - mu) / sigma, 0.0, 1.0) -
+            normal_cdf((log(small) - mu) / sigma, 0.0, 1.0)));
   }
   
   


### PR DESCRIPTION
Currently, the discretised delay distributions aren't correctly normalised. Because of this, they can sum up to less than 1, and this currently happens in the second lognormal delay. I suspect this is behind the current issue where infections can be consistently above reported cases. I think it is fixed in this commit.