### PR TITLE
Suppress region printing

### DIFF
--- a/R/epinow.R
+++ b/R/epinow.R
@@ -392,9 +392,17 @@ clean_regions <- function(reported_cases, non_zero_points) {
                                                      .(confirm = sum(confirm, na.rm = TRUE)), by = "region"][confirm >= non_zero_points]$region
   
   eval_regions <- unique(eval_regions)
-  
-  futile.logger::flog.info("Producing estimates for: %s",
-                           paste(eval_regions, collapse = ", "))
+  orig_regions <- length(unique(reported_cases$region))
+  if (length(eval_regions) > 30){
+    futile.logger::flog.info("Producing estimates for %s regions out of %s",
+                             length(eval_regions), length(orig_regions))
+  }else{
+    futile.logger::flog.info("Producing estimates for: %s",
+                             paste(eval_regions, collapse = ", "))
+    futile.logger::flog.info("Regions excluded: %s",
+                             paste(orig_regions, collapse = ", "))
+  }
+
   
   ## Exclude zero regions
   reported_cases <- reported_cases[!is.na(region)][region %in% eval_regions]

--- a/R/epinow.R
+++ b/R/epinow.R
@@ -392,12 +392,12 @@ clean_regions <- function(reported_cases, non_zero_points) {
                                                      .(confirm = sum(confirm, na.rm = TRUE)), by = "region"][confirm >= non_zero_points]$region
   
   eval_regions <- unique(eval_regions)
-  orig_regions <- length(unique(reported_cases$region))
+  orig_regions <- setdiff(unique(reported_cases$region), eval_regions)
   if (length(eval_regions) > 30){
     futile.logger::flog.info("Producing estimates for: %s regions",
                              length(eval_regions))
     futile.logger::flog.info("Regions excluded: %s regions",
-                             length(orig_regions))
+                             length(orig_regions) - length(eval_regions))
   }else{
     futile.logger::flog.info("Producing estimates for: %s",
                              paste(eval_regions, collapse = ", "))

--- a/R/epinow.R
+++ b/R/epinow.R
@@ -396,8 +396,10 @@ clean_regions <- function(reported_cases, non_zero_points) {
   if (length(eval_regions) > 30){
     futile.logger::flog.info("Producing estimates for: %s regions",
                              length(eval_regions))
+    message <- ifelse(length(orig_regions) == 0, 0, 
+                      (length(orig_regions) - length(eval_regions)))
     futile.logger::flog.info("Regions excluded: %s regions",
-                             (length(orig_regions) - length(eval_regions)))
+                             message)
   }else{
     futile.logger::flog.info("Producing estimates for: %s",
                              paste(eval_regions, collapse = ", "))

--- a/R/epinow.R
+++ b/R/epinow.R
@@ -394,8 +394,10 @@ clean_regions <- function(reported_cases, non_zero_points) {
   eval_regions <- unique(eval_regions)
   orig_regions <- length(unique(reported_cases$region))
   if (length(eval_regions) > 30){
-    futile.logger::flog.info("Producing estimates for %s regions out of %s",
-                             length(eval_regions), length(orig_regions))
+    futile.logger::flog.info("Producing estimates for: %s regions",
+                             length(eval_regions))
+    futile.logger::flog.info("Regions excluded: %s regions",
+                             length(orig_regions))
   }else{
     futile.logger::flog.info("Producing estimates for: %s",
                              paste(eval_regions, collapse = ", "))

--- a/R/epinow.R
+++ b/R/epinow.R
@@ -397,12 +397,14 @@ clean_regions <- function(reported_cases, non_zero_points) {
     futile.logger::flog.info("Producing estimates for: %s regions",
                              length(eval_regions))
     futile.logger::flog.info("Regions excluded: %s regions",
-                             length(orig_regions) - length(eval_regions))
+                             (length(orig_regions) - length(eval_regions)))
   }else{
     futile.logger::flog.info("Producing estimates for: %s",
                              paste(eval_regions, collapse = ", "))
+    message <- ifelse(length(orig_regions) == 0, "none", 
+                      paste(orig_regions, collapse = ", "))
     futile.logger::flog.info("Regions excluded: %s",
-                             paste(orig_regions, collapse = ", "))
+                             message)
   }
 
   


### PR DESCRIPTION
This PR adds a switch when there are more than 30 regions so that instead of printing the names of all the regions to produce estimates for it logs the number of regions (and the total number of regions). It also adds a region excluded logging message in order to highlight when this is happening.