### PR TITLE
stan: functions: constrain Gamma shape and (inverse) scale > 0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Added `get_dist`, `get_generation_time`, `get_incubation_period` based on ideas from @pearsonca. (This leads to breaking changes with the removal of `covid_generation_times` and `covid_incubation_periods`).
 * Added support for either NUTs sampling (`method = "exact"`) or Variational inference (`method = "approximate"`).
 * Added `setup_logging` to enable users to specify the level and location of logging (wrapping functionality from `futile.logger`). 
+* Updated `discretised_gamma_pmf` (discretised truncated Gamma PMF) to constrain gamma shape and (inverse) scale parameters to be positive and finite (`alpha > 0` and `beta > 0`).
 
 # EpiNow2 1.1.0
 

--- a/inst/stan/functions/discretised_gamma_pmf.stan
+++ b/inst/stan/functions/discretised_gamma_pmf.stan
@@ -5,8 +5,8 @@
     real alpha = ((mu)/ c_sigma)^2;
     real beta = (mu) / (c_sigma^2);
     //account for numerical issues
-    alpha = alpha < 0 ? 1e-5 : alpha;
-    beta = beta < 0 ? 1e-5 : beta; 
+    alpha = alpha <= 0 ? 1e-5 : alpha;
+    beta = beta <= 0 ? 1e-5 : beta;
     alpha = is_inf(alpha) ? 1e8 : alpha;
     beta = is_inf(beta) ? 1e8 : beta; 
     return((gamma_cdf(y + 1, alpha, beta) - gamma_cdf(y, alpha, beta)) / 


### PR DESCRIPTION
Updated discretised_gamma_pmf (discretised truncated Gamma PMF) to constrain gamma shape and (inverse) scale parameters to be positive and finite (alpha > 0 and beta > 0).

Fixing the following message:

Chain 1 Informational Message: The current Metropolis proposal is about to be rejected because of the following issue:
Chain 1 Exception: Exception: gamma_cdf: Shape parameter is 0, but must be positive and finite!