### PR TITLE
add regional summary button

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,7 @@
 * Updated `discretised_gamma_pmf` (discretised truncated Gamma PMF) to constrain gamma shape and (inverse) scale parameters to be positive and finite (`alpha > 0` and `beta > 0`).
 * Fixed `readLines` incomplete final line warnings.
 * Implemented progress bar support using `progressr`.
+* Adds a csv download button the interactive table in the regional summary table.
 
 # EpiNow2 1.1.0
 

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -100,7 +100,8 @@ if (!interactive) {
    kableExtra::landscape()
 }else{
   data.table::fread(here::here(summary_path, "summary_table.csv")) %>% 
-    DT::datatable(extensions = c("Buttons"), 
+    DT::datatable(rownames = FALSE,
+                  extensions = c("Buttons"), 
                   options = list(dom = "Bfrtip", buttons = c("csv")))
 } 
 ```

--- a/inst/templates/_regional-summary.Rmd
+++ b/inst/templates/_regional-summary.Rmd
@@ -100,7 +100,8 @@ if (!interactive) {
    kableExtra::landscape()
 }else{
   data.table::fread(here::here(summary_path, "summary_table.csv")) %>% 
-    DT::datatable()
+    DT::datatable(extensions = c("Buttons"), 
+                  options = list(dom = "Bfrtip", buttons = c("csv")))
 } 
 ```
 


### PR DESCRIPTION
Adds a downloads csv button to the interactive tables supplied in the regional summary template. Limited impact on downstream users as templates are not currently supported for outside users. 