### PR TITLE
Rt prior to log normal

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@ This release introduces multiple breaking interface changes. Please see the READ
 ## New features
 
 * Added support for either NUTs sampling (`method = "exact"`) or Variational inference (`method = "approximate"`).
+* Update the prior on the initial Rt estimate to be lognormal rather than gamma distributed. For users the interface remains unchanged but this parameterisation should be more numerically stable.
 * Added `get_dist`, `get_generation_time`, `get_incubation_period` based on ideas from @pearsonca. (This leads to breaking changes with the removal of `covid_generation_times` and `covid_incubation_periods`).
 * Added `setup_logging` to enable users to specify the level and location of logging (wrapping functionality from `futile.logger`). Also added `setup_default_logging` to give users sensible defaults and embedded this
 function in `regional_epinow` and `epinow`.

--- a/R/create.R
+++ b/R/create.R
@@ -203,8 +203,8 @@ create_initial_conditions <- function(data, delays, rt_prior, generation_time, m
     
     if (data$estimate_r == 1) {
       out$initial_infections <- array(rlnorm(mean_shift, meanlog = 0, sdlog = 0.1))
-      out$initial_R <- array(rgamma(n = 1, shape = (rt_prior$mean / rt_prior$sd)^2, 
-                                    scale = (rt_prior$sd^2) / rt_prior$mean))
+      out$initial_R <- array(rnorm(n = 1, mean = log(rt_prior$mean^2 / sqrt(rt_prior$sd^2 + rt_prior$mean^2)), 
+                                   sd = sqrt(log(1 + (rt_prior$sd^2 / rt_prior$mean^2)))))
       out$gt_mean <- array(truncnorm::rtruncnorm(1, a = 0, mean = generation_time$mean,  
                                                  sd = generation_time$mean_sd))
       out$gt_sd <-  array(truncnorm::rtruncnorm(1, a = 0, mean = generation_time$sd,

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -81,7 +81,7 @@
 #' # these settings are not suggesed for real world use.                   
 #' # run model with default setting
 #' def <- estimate_infections(reported_cases, generation_time = generation_time,
-#'                            delays = list(incubation_period, reporting_delay), model = model, verbose = TRUE,
+#'                            delays = list(incubation_period, reporting_delay), 
 #'                            stan_args = list(warmup = 200, control = list(adapt_delta = 0.8),
 #'                                             cores = ifelse(interactive(), 4, 1)))
 #'

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -14,9 +14,9 @@
 #' standard deviation (sd), standard deviation of the standard deviation and the maximum allowed value for the
 #' that delay (assuming a lognormal distribution with all parameters excepting the max allowed value 
 #' on the log scale). To use no delays set this to `list()`.
-#' @param rt_prior A list contain the mean and standard deviation (sd) of the gamma distributed prior for
-#' Rt. By default this is assumed to be mean 1 with a standard deviation of 1. To infer infections only using 
-#' non-parametric backcalculation set this to `list()`.
+#' @param rt_prior A list contain the mean and standard deviation (sd) of the lognormally distributed prior for
+#' Rt. By default this is assumed to be mean 1 with a standard deviation of 1 (note in model these will be mapped to
+#' log space). To infer infections only using non-parametric backcalculation set this to `list()`.
 #' @param prior_smoothing_window Numeric defaults to 7. The number of days over which to take a rolling average
 #' for the prior based on reported cases.
 #' @param horizon Numeric, defaults to 7. Number of days into the future to forecast.
@@ -81,7 +81,7 @@
 #' # these settings are not suggesed for real world use.                   
 #' # run model with default setting
 #' def <- estimate_infections(reported_cases, generation_time = generation_time,
-#'                            delays = list(incubation_period, reporting_delay),
+#'                            delays = list(incubation_period, reporting_delay), model = model, verbose = TRUE,
 #'                            stan_args = list(warmup = 200, control = list(adapt_delta = 0.8),
 #'                                             cores = ifelse(interactive(), 4, 1)))
 #'

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -233,6 +233,11 @@ model {
   eta ~ std_normal();
   }
 
+  // reporting overdispersion
+  if (model_type) {
+    rep_phi[model_type] ~ exponential(1);
+  }
+
   // penalised priors for delaysincubation period, and report delay
   if (delays) {
     for (s in 1:delays) {
@@ -259,7 +264,7 @@ model {
 
   // daily cases given reports
   if (model_type) {
-    target += neg_binomial_2_lpmf(cases | reports[1:rt_h], 1/sqrt(rep_phi[model_type]));
+    target += neg_binomial_2_lpmf(cases | reports[1:rt_h], rep_phi[model_type]);
   }else{
     target += poisson_lpmf(cases | reports[1:rt_h]);
   }
@@ -280,7 +285,7 @@ generated quantities {
   //simulate reported cases
   if (model_type) {
     for (s in 1:rt) {
-      imputed_reports[s] = neg_binomial_2_rng(reports[s] > 1e7 ? 1e7 : reports[s], 1/sqrt(rep_phi[model_type]));
+      imputed_reports[s] = neg_binomial_2_rng(reports[s] > 1e7 ? 1e7 : reports[s], rep_phi[model_type]);
     }
    }else{
     for (s in 1:rt) {

--- a/man/create_initial_conditions.Rd
+++ b/man/create_initial_conditions.Rd
@@ -15,9 +15,9 @@ standard deviation (sd), standard deviation of the standard deviation and the ma
 that delay (assuming a lognormal distribution with all parameters excepting the max allowed value
 on the log scale). To use no delays set this to \code{list()}.}
 
-\item{rt_prior}{A list contain the mean and standard deviation (sd) of the gamma distributed prior for
-Rt. By default this is assumed to be mean 1 with a standard deviation of 1. To infer infections only using
-non-parametric backcalculation set this to \code{list()}.}
+\item{rt_prior}{A list contain the mean and standard deviation (sd) of the lognormally distributed prior for
+Rt. By default this is assumed to be mean 1 with a standard deviation of 1 (note in model these will be mapped to
+log space). To infer infections only using non-parametric backcalculation set this to \code{list()}.}
 
 \item{generation_time}{A list containing the mean, standard deviation of the mean (mean_sd),
 standard deviation (sd), standard deviation of the standard deviation and the maximum allowed value for the

--- a/man/create_stan_data.Rd
+++ b/man/create_stan_data.Rd
@@ -39,9 +39,9 @@ in date format.}
 standard deviation (sd), standard deviation of the standard deviation and the maximum allowed value for the
 generation time (assuming a gamma distribution).}
 
-\item{rt_prior}{A list contain the mean and standard deviation (sd) of the gamma distributed prior for
-Rt. By default this is assumed to be mean 1 with a standard deviation of 1. To infer infections only using
-non-parametric backcalculation set this to \code{list()}.}
+\item{rt_prior}{A list contain the mean and standard deviation (sd) of the lognormally distributed prior for
+Rt. By default this is assumed to be mean 1 with a standard deviation of 1 (note in model these will be mapped to
+log space). To infer infections only using non-parametric backcalculation set this to \code{list()}.}
 
 \item{estimate_rt}{Logical, should Rt be estimated.}
 

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -138,7 +138,7 @@ reporting_delay <- list(mean = log(5), mean_sd = log(2),
 # these settings are not suggesed for real world use.                   
 # run model with default setting
 def <- estimate_infections(reported_cases, generation_time = generation_time,
-                           delays = list(incubation_period, reporting_delay), model = model, verbose = TRUE,
+                           delays = list(incubation_period, reporting_delay), 
                            stan_args = list(warmup = 200, control = list(adapt_delta = 0.8),
                                             cores = ifelse(interactive(), 4, 1)))
 

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -75,9 +75,9 @@ values can be obtained using \code{tune_inv_gamma} which optimises based on the 
 of the observed data). The default is tuned to have 98\% of the density of the distribution between 2 and 21 days. Finally the list must
 contain \code{alpha_sd} the standard deviation for the alpha parameter of the gaussian process. This defaults to 0.1.}
 
-\item{rt_prior}{A list contain the mean and standard deviation (sd) of the gamma distributed prior for
-Rt. By default this is assumed to be mean 1 with a standard deviation of 1. To infer infections only using
-non-parametric backcalculation set this to \code{list()}.}
+\item{rt_prior}{A list contain the mean and standard deviation (sd) of the lognormally distributed prior for
+Rt. By default this is assumed to be mean 1 with a standard deviation of 1 (note in model these will be mapped to
+log space). To infer infections only using non-parametric backcalculation set this to \code{list()}.}
 
 \item{week_effect}{Logical, defaults TRUE. Should weekly reporting effects be estimated.}
 
@@ -138,7 +138,7 @@ reporting_delay <- list(mean = log(5), mean_sd = log(2),
 # these settings are not suggesed for real world use.                   
 # run model with default setting
 def <- estimate_infections(reported_cases, generation_time = generation_time,
-                           delays = list(incubation_period, reporting_delay), 
+                           delays = list(incubation_period, reporting_delay), model = model, verbose = TRUE,
                            stan_args = list(warmup = 200, control = list(adapt_delta = 0.8),
                                             cores = ifelse(interactive(), 4, 1)))
 


### PR DESCRIPTION
As discussed with @jhellewell14 this PR moves the prior on Rt to lognormal from gamma as this allows us to skips a log -> exp repeated transform in model. 