### PR TITLE
Explore initialisation of infectiousness

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -67,11 +67,11 @@ extract_parameter_samples <- function(stan_fit, data, reported_dates, reported_i
   if (data$estimate_r == 1) {
     out$R <- extract_parameter("R", 
                                samples,
-                               reported_dates)
+                               reported_inf_dates)
     
     out$growth_rate <- extract_parameter("r", 
                                          samples,
-                                         reported_dates)
+                                         reported_inf_dates)
     
     if (data$break_no > 0) {
       out$breakpoints <- extract_parameter("rt_break_eff", 


### PR DESCRIPTION
As discussed with @jhellewell14 this PR explores moving from initializing infections prior to estimate Rt (only for unobserved infections) and instead initializes a single prior on the first summed infectiousness. 

There are two complexities here: 1. How indexing works in terms of what is reported and what is generated (because we have unobserved and observed time with unobserved time mapping to observed time). and 2. If initial infectiousness is correctly shared across early Rt estimates. 

This PR is a work in progress and currently, indexing is not correct and infectiousness is not properly updated for early Rt estimate . 