### PR TITLE
stan: negbin: defer to poisson if phi is large

### DIFF
--- a/inst/stan/functions/generated_quantities.stan
+++ b/inst/stan/functions/generated_quantities.stan
@@ -14,9 +14,14 @@ int[] report_rng(vector reports, real[] rep_phi, int model_type) {
   int sampled_reports[t];
   if (model_type) {
     for (s in 1:t) {
-      sampled_reports[s] = neg_binomial_2_rng(reports[s] > 1e8 ? 1e8 : reports[s], rep_phi[model_type]);
+      // defer to poisson if phi is large, to avoid overflow
+      if (rep_phi[model_type] > 1e5) {
+        sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
+      } else {
+        sampled_reports[s] = neg_binomial_2_rng(reports[s] > 1e8 ? 1e8 : reports[s], rep_phi[model_type]);
+      }
     }
-  }else{
+  } else {
     for (s in 1:t) {
       sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
     }

--- a/inst/stan/functions/generated_quantities.stan
+++ b/inst/stan/functions/generated_quantities.stan
@@ -15,7 +15,7 @@ int[] report_rng(vector reports, real[] rep_phi, int model_type) {
   if (model_type) {
     for (s in 1:t) {
       // defer to poisson if phi is large, to avoid overflow
-      if (rep_phi[model_type] > 1e5) {
+      if (rep_phi[model_type] > 1e4) {
         sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
       } else {
         sampled_reports[s] = neg_binomial_2_rng(reports[s] > 1e8 ? 1e8 : reports[s], rep_phi[model_type]);

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -21,7 +21,7 @@ void report_lp(int[] cases, vector reports,
     // the reciprocal overdispersion parameter (phi)
     rep_phi[model_type] ~ exponential(phi_prior);
     // defer to poisson if phi is large, to avoid overflow
-    if (rep_phi[model_type] > 1e5) {
+    if (rep_phi[model_type] > 1e4) {
       target += poisson_lpmf(cases | reports[1:t]) * weight;
     } else {
       target += neg_binomial_2_lpmf(cases | reports[1:t], rep_phi[model_type]) * weight;

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -18,10 +18,15 @@ void report_lp(int[] cases, vector reports,
                int weight) {
   int t = num_elements(reports) - horizon;
   if (model_type) {
-    //overdispersion
+    // the reciprocal overdispersion parameter (phi)
     rep_phi[model_type] ~ exponential(phi_prior);
-    target += neg_binomial_2_lpmf(cases | reports[1:t], rep_phi[model_type]) * weight;
-  }else{
+    // defer to poisson if phi is large, to avoid overflow
+    if (rep_phi[model_type] > 1e5) {
+      target += poisson_lpmf(cases | reports[1:t]) * weight;
+    } else {
+      target += neg_binomial_2_lpmf(cases | reports[1:t], rep_phi[model_type]) * weight;
+    }
+  } else {
     target += poisson_lpmf(cases | reports[1:t]) * weight;
   }
 }


### PR DESCRIPTION
Defer to poisson distribution if the reciprocal overdispersion parameter
of the negative binomial distribution (phi) is large, to avoid overflows.

See https://github.com/stan-dev/math/pull/466

Fixes #143