### PR TITLE
Speed up simulate infections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Reworked the package logging system to improve the reporting of issues both in `epinow` and in `regional_epinow` for large batch runs.
 * Fix from @hsbadr to prevent overflow when overdispersion is larger (by switching to a Poisson approximation). Hitting this issue may indicate a bug in other model code that will need further work to explore.
 * Moved default verbosity for all functions (excepting `regional_epinow`) to be based on whether or not usage is interactive. 
+* Depreciated `burn_in` argument of `estimate_infections` as updates to model initialisation mean that this feature is likely no longer needed. Please contact the developers if you feel you have a use case for this argument.
 
 # EpiNow2 1.2.1
 

--- a/R/create.R
+++ b/R/create.R
@@ -109,10 +109,11 @@ create_future_rt <- function(future_rt = "project", delay = 0) {
 #' @importFrom purrr safely
 #' @return A list of stan data
 #' @export 
-create_stan_data <- function(reported_cases,  shifted_reported_cases,
+create_stan_data <- function(reported_cases, shifted_reported_cases,
                              horizon, no_delays, mean_shift, generation_time,
-                             rt_prior, estimate_rt, week_effect, stationary,
-                             fixed, break_no, future_rt, gp, family, delays) {
+                             rt_prior, estimate_rt, burn_in, week_effect,
+                             stationary, fixed, break_no, future_rt, gp, family,
+                             delays) {
   # create future_rt
   future_rt <- create_future_rt(future_rt = future_rt, 
                                 delay = mean_shift)
@@ -135,6 +136,7 @@ create_stan_data <- function(reported_cases,  shifted_reported_cases,
     r_mean = rt_prior$mean,
     r_sd = rt_prior$sd,
     estimate_r = ifelse(estimate_rt, 1, 0),
+    burn_in = burn_in,
     week_effect = ifelse(week_effect, 1, 0),
     stationary = ifelse(stationary, 1, 0),
     fixed = ifelse(fixed, 1, 0),

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -27,10 +27,8 @@
 #'  Breakpoints should be defined as 1 if present and otherwise 0. By default breakpoints are fit jointly with
 #' a global non-parametric effect and so represent a conservative estimate of breakpoint changes. To specify a random walk define
 #' breakpoints every n days (so every 7 days for a weekly random walk) and disable the gaussian process using `gp = list()`.
-#' @param burn_in Numeric, defaults to 0. The number of initial Rt estimates to discard. This argument may be used to reduce 
-#' spurious findings when running `estimate_infections` on a partial timeseries (as the earliest estimates will not be informed by 
-#' all cases that occurred only those supplied to `estimate_infections`). The combined delays used will inform the appropriate length
-#' of this burn in but 7 days is likely a sensible starting point.
+#' @param burn_in Numeric, defaults to 0. The number of initial Rt estimates to discard. This argument is depreciated and will be 
+#' removed from the package unless a clear user need is given.
 #' @param stationary Logical, defaults to FALSE. Should Rt be estimated with a global mean. When estimating Rt 
 #' this should substantially improve run times but will revert to the global average for real time and forecasted estimates.
 #' This setting is most appropriate when estimating historic Rt or when combined with breakpoints.
@@ -114,8 +112,7 @@
 #'                                 stan_args = 
 #'                                    list(warmup = 200, 
 #'                                         control = list(adapt_delta = 0.95, max_treedepth = 15),
-#'                                         cores = ifelse(interactive(), 4, 1)),
-#'                                 burn_in = 7)
+#'                                         cores = ifelse(interactive(), 4, 1)))
 #' plot(snapshot) 
 #' 
 #' # run model with stationary Rt assumption (likely to provide biased real-time estimates)
@@ -186,6 +183,10 @@ estimate_infections <- function(reported_cases,
                                 id = "estimate_infections",
                                 verbose = interactive()){
    
+  if (burn_in > 0) {
+    message("burn_in is depreciated as of EpiNow2 1.3.0 - if using this feature please contact the developers")
+  }
+  
   # store dirty reported case data
   dirty_reported_cases <- data.table::copy(reported_cases)
   # set fall back rt prior and trigger switches
@@ -277,6 +278,7 @@ estimate_infections <- function(reported_cases,
                            generation_time = generation_time,
                            rt_prior = rt_prior, 
                            estimate_rt = estimate_rt,
+                           burn_in = burn_in,
                            week_effect = week_effect, 
                            stationary = stationary,
                            fixed = fixed,
@@ -525,6 +527,7 @@ format_fit <- function(posterior_samples, horizon, shift, burn_in, start_date,
   
   # remove burn in period if specified
   if (burn_in > 0) {
+    message("burn_in is depreciated as of EpiNow2 1.3.0 - if using this feature please contact the developers")
     format_out$samples <- format_out$samples[is.na(date) | date >= (start_date + lubridate::days(burn_in))]
   }
   

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -84,7 +84,7 @@ simulate_infections <- function(estimates,
   
   # extract parameters for extract_parameter_samples from passed stanfit object
   shift <- estimates$args$seeding_time
-  dates <- na.omit(unique(estimates$samples$date))
+  dates <- na.omit(unique(estimates$summarised$date))
   
   # Load model
   if (is.null(model)) {

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -85,7 +85,7 @@ simulate_infections <- function(estimates,
   # extract parameters for extract_parameter_samples from passed stanfit object
   shift <- estimates$args$seeding_time
   dates <- seq(min(na.omit(unique(estimates$summarised$date))), 
-                   by = "day", length.out = length(R) + shift)
+                   by = "day", length.out = dim(draws$R)[2] + shift)
   
   # Load model
   if (is.null(model)) {

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -11,6 +11,8 @@
 #'  estimated reproduction numbers are taken as forecast.
 #' @param samples Numeric, number of posterior samples to simulate from. The default is to use all
 #' samples in the `estimates` input.
+#' @param batch_size Numeric, defaults to 100. Size of batches in which to simulate. May decrease 
+#' runtimes due to reduced IO costs.
 #' @importFrom rstan extract sampling
 #' @inheritParams estimate_infections
 #' @export

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -17,6 +17,7 @@
 #' @importFrom purrr transpose map
 #' @importFrom future.apply future_lapply
 #' @importFrom progressr with_progress progressor
+#' @importFrom data.table rbindlist
 #' @inheritParams estimate_infections
 #' @export
 #' @examples

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -13,6 +13,8 @@
 #' samples in the `estimates` input.
 #' @param batch_size Numeric, defaults to 100. Size of batches in which to simulate. May decrease 
 #' runtimes due to reduced IO costs. If set to NULL then all simulations are done at once.
+#' @param verbose Logical defaults to `interactive()`. Should a progress bar (from `progressr`) be
+#' shown.
 #' @importFrom rstan extract sampling
 #' @importFrom purrr transpose map
 #' @importFrom future.apply future_lapply

--- a/inst/stan/simulate_infections.stan
+++ b/inst/stan/simulate_infections.stan
@@ -14,7 +14,7 @@ data {
   int t; // unobserved time
   int seeding_time; // time period used for seeding and not observed
   // Rt
-  real initial_infections[seeding_time ? n : 0 ,1]; // initial logged infections
+  real initial_infections[seeding_time ? n : 0, 1]; // initial logged infections
   real initial_growth[seeding_time > 1 ? n : 0, 1]; //initial growth
   real<lower = 0> gt_mean[n, 1];  // mean of generation time
   real<lower = 0> gt_sd[n, 1];   // sd of generation time

--- a/man/create_stan_data.Rd
+++ b/man/create_stan_data.Rd
@@ -13,6 +13,7 @@ create_stan_data(
   generation_time,
   rt_prior,
   estimate_rt,
+  burn_in,
   week_effect,
   stationary,
   fixed,
@@ -44,6 +45,9 @@ Rt. By default this is assumed to be mean 1 with a standard deviation of 1 (note
 log space). To infer infections and then calculate Rt using backcalculation set this to \code{list()}.}
 
 \item{estimate_rt}{Logical, should Rt be estimated.}
+
+\item{burn_in}{Numeric, defaults to 0. The number of initial Rt estimates to discard. This argument is depreciated and will be
+removed from the package unless a clear user need is given.}
 
 \item{week_effect}{Logical, defaults TRUE. Should weekly reporting effects be estimated.}
 

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -96,10 +96,8 @@ options are to project using the Rt model ("project"), to use the latest estimat
 to use the latest estimate based on data that is over 50\% complete ("estimate"). If an integer is supplied then the Rt estimate
 from this many days into the future (or past if negative) past will be used forwards in time.}
 
-\item{burn_in}{Numeric, defaults to 0. The number of initial Rt estimates to discard. This argument may be used to reduce
-spurious findings when running \code{estimate_infections} on a partial timeseries (as the earliest estimates will not be informed by
-all cases that occurred only those supplied to \code{estimate_infections}). The combined delays used will inform the appropriate length
-of this burn in but 7 days is likely a sensible starting point.}
+\item{burn_in}{Numeric, defaults to 0. The number of initial Rt estimates to discard. This argument is depreciated and will be
+removed from the package unless a clear user need is given.}
 
 \item{prior_smoothing_window}{Numeric defaults to 7. The number of days over which to take a rolling average
 for the prior based on reported cases.}
@@ -175,8 +173,7 @@ snapshot <- estimate_infections(snapshot_cases, generation_time = generation_tim
                                 stan_args = 
                                    list(warmup = 200, 
                                         control = list(adapt_delta = 0.95, max_treedepth = 15),
-                                        cores = ifelse(interactive(), 4, 1)),
-                                burn_in = 7)
+                                        cores = ifelse(interactive(), 4, 1)))
 plot(snapshot) 
 
 # run model with stationary Rt assumption (likely to provide biased real-time estimates)

--- a/man/simulate_infections.Rd
+++ b/man/simulate_infections.Rd
@@ -28,15 +28,15 @@ estimated reproduction numbers are taken as forecast.}
 samples in the \code{estimates} input.}
 
 \item{batch_size}{Numeric, defaults to 100. Size of batches in which to simulate. May decrease
-runtimes due to reduced IO costs.}
+runtimes due to reduced IO costs. If set to NULL then all simulations are done at once.}
 
-\item{verbose}{Logical, defaults to \code{TRUE} when used interactively and otherwise \code{FALSE}. Should verbose debug progress messages be printed. Corresponds to the "DEBUG" level from
-\code{futile.logger}. See \code{setup_logging} for more detailed logging options.}
+\item{verbose}{Logical defaults to \code{interactive()}. Should a progress bar (from \code{progressr}) be
+shown.}
 }
 \description{
 This function simulates infections using an existing fit to observed cases but
 with a modified time-varying reproduction number. This can be used to explore forecast models
-or past counterfactuals.
+or past counterfactuals. Simulations can be run in parallel using \code{future::plan}.
 }
 \examples{
 \donttest{
@@ -59,8 +59,8 @@ est <- estimate_infections(reported_cases, generation_time = generation_time,
                                   cores = ifelse(interactive(), 4, 1)))
                                   
 # update Rt trajectory and simulate new infections using it
-R <- c(rep(NA_real_, 40), rep(0.5, 17))
-sims <- simulate_infections(est, R, verbose = FALSE)
+R <- c(rep(NA_real_, 40), rep(0.5, 10), rep(0.8, 7))
+sims <- simulate_infections(est, R)
 plot(sims)
 }
 }

--- a/man/simulate_infections.Rd
+++ b/man/simulate_infections.Rd
@@ -4,20 +4,39 @@
 \alias{simulate_infections}
 \title{Simulate infections using a given trajectory of the time-varying reproduction number}
 \usage{
-simulate_infections(estimates, R = NULL, model = NULL, verbose = interactive())
+simulate_infections(
+  estimates,
+  R = NULL,
+  model = NULL,
+  samples = NULL,
+  batch_size = 10,
+  verbose = interactive()
+)
 }
 \arguments{
-\item{estimates}{The \code{estimates} element of an \code{epinow} run that has been done with output = "fit", or the result of \code{estimate_infections} with \code{return_fit} set to TRUE.}
+\item{estimates}{The \code{estimates} element of an \code{epinow} run that has been done with
+output = "fit", or the result of \code{estimate_infections} with \code{return_fit} set to TRUE.}
 
-\item{R}{A numeric vector of reproduction numbers; these will overwrite the reproduction numbers contained in \code{estimates}, except elements set to NA. If it is longer than the time series of reproduction numbers contained in \code{estimates}, the values going beyond the length of estimated reproduction numbers are taken as forecast.}
+\item{R}{A numeric vector of reproduction numbers; these will overwrite the reproduction numbers
+contained in \code{estimates}, except elements set to NA. If it is longer than the time series
+of reproduction numbers contained in \code{estimates}, the values going beyond the length of
+estimated reproduction numbers are taken as forecast.}
 
 \item{model}{A compiled stan model. By default uses the internal package model.}
+
+\item{samples}{Numeric, number of posterior samples to simulate from. The default is to use all
+samples in the \code{estimates} input.}
+
+\item{batch_size}{Numeric, defaults to 100. Size of batches in which to simulate. May decrease
+runtimes due to reduced IO costs.}
 
 \item{verbose}{Logical, defaults to \code{TRUE} when used interactively and otherwise \code{FALSE}. Should verbose debug progress messages be printed. Corresponds to the "DEBUG" level from
 \code{futile.logger}. See \code{setup_logging} for more detailed logging options.}
 }
 \description{
-This function simulates infections using an existing fit to observed cases but with a modified time-varying reproduction number. This can be used to explore forecast models or past counterfactuals.
+This function simulates infections using an existing fit to observed cases but
+with a modified time-varying reproduction number. This can be used to explore forecast models
+or past counterfactuals.
 }
 \examples{
 \donttest{
@@ -41,7 +60,7 @@ est <- estimate_infections(reported_cases, generation_time = generation_time,
                                   
 # update Rt trajectory and simulate new infections using it
 R <- c(rep(NA_real_, 40), rep(0.5, 17))
-sims <- simulate_infections(est, R)
+sims <- simulate_infections(est, R, verbose = FALSE)
 plot(sims)
 }
 }

--- a/tests/testthat/test-simulate_infections.R
+++ b/tests/testthat/test-simulate_infections.R
@@ -28,3 +28,18 @@ test_that("simulate infections fails as expected", {
   expect_error(simualate_infections(out, R = rep(1, 10)))
   expect_error(simulate_infections(out[-"fit"]))
 })
+
+out <- suppressWarnings(estimate_infections(reported_cases, generation_time = generation_time,
+                                            delays = list(reporting_delay), samples = 50, 
+                                            stan_args = list(chains = 2, warmup = 50,
+                                                             control = list(adapt_delta = 0.8))))
+
+test_that("simulate_infections supports the burn_in arg", {
+  out <- suppressWarnings(estimate_infections(reported_cases, generation_time = generation_time,
+                                              delays = list(reporting_delay), samples = 50, 
+                                              stan_args = list(chains = 2, warmup = 50,
+                                                               control = list(adapt_delta = 0.8)),
+                                              burn_in = 7))
+  sims <- simulate_infections(out)
+  expect_equal(names(sims), c("samples", "summarised", "observations"))
+})


### PR DESCRIPTION
The new `simulate_infections` appears to have a massive IO cost from moving around data. For a real use case (UK scenarios) run time is at least 6 hours (still running). 

This PR attempts to reduce this cost and hence speed up the run times. It does this in two ways 1. by only passing samples that are needed to `simulate_infections.stan` and 2. by running samples in batches (with the user also now able to control the number of posterior samples used). 

Additionals features of this PR are: 

* Added a progress bar for `simulate_infections`
* Added parallel support for `simulate_infections`.
* Depreciates `burn_in` arg as no longer needed with new initialisation. 
* Adds support for `burn_in` to `simulate_infections` whilst still present.


Timing indicates that using a batch size of 10 speeds up the example from 9 minutes to 10s . I don't clearly understand why this is the case and perhaps there is a mistake. 