### PR TITLE
Close stationary GP and breakpoints edge case

### DIFF
--- a/inst/stan/functions/rt.stan
+++ b/inst/stan/functions/rt.stan
@@ -44,6 +44,7 @@ vector update_Rt(vector input_R, real log_R, vector noise, int[] bps,
   // define control parameters
   int noise_terms = num_elements(noise);
   int i_stationary = noise_terms > 0 ? stationary : 1;
+  int bp_stat;
   int t = num_elements(input_R);
   int bp_n = num_elements(bp_effects);
   int bp_in = 0;
@@ -64,7 +65,8 @@ vector update_Rt(vector input_R, real log_R, vector noise, int[] bps,
     if (bp_n > 0) {
       at_bp = bps[s];
       bp_in += at_bp;
-      R[s] = update_breakpoints(R[s], bp_effects, bp_in, at_bp, i_stationary);
+      bp_stat = index > noise_terms ? 0 : i_stationary;
+      R[s] = update_breakpoints(R[s], bp_effects, bp_in, at_bp, bp_stat);
     }
   }
   // convert to correct scale


### PR DESCRIPTION
There is currently an edge case where breakpoints are added multiple times when a stationary GP is used, fewer noise terms than timepoints are used (i.e `future_rt` is not "project"), and breakpoints are present beyond the range of the Gaussian process. 

This PR closes this by adding a switch to non-stationary behaviour for the breakpoint updating when this scenario occurs. Ideally this would be dealt with by supporting fewer varients (i.e not supporting the stationary gaussian process etc). Alternatively if embracing the definition of stationary then the default for Rt beyond the range of the GP should really be the global mean Rt and not the previously recorded Rt (and it is in fact this requirement which introduces the issue). 

As none of these settings are default and this edge case is likely quite rare this PR is low priority. 