### PR TITLE
stan: Properly clip/limit the values of the parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@ This choice means that increasing the `prior` window does not alter the location
 a right alighted moving average.
 * Updates the default smoothing applied to mean shifted reported cases to be 14 days rather than 7 as usage indicates this 
 provided too much weight to small scale changes. This remains user set able.
+* Updates `discretised_gamma_pmf` (discretised truncated Gamma PMF) and `discretised_lognormal_pmf` (discretised truncated lognormal PMF) 
+to properly limit/clip the values of the parameters by prespecified lower and upper bounds.
 
 # EpiNow2 1.3.1
 

--- a/inst/stan/functions/pmfs.stan
+++ b/inst/stan/functions/pmfs.stan
@@ -4,14 +4,17 @@ vector discretised_gamma_pmf(int[] y, real mu, real sigma, int max_val) {
   vector[n] pmf;
   real trunc_pmf;
   // calculate alpha and beta for gamma distribution
-  real c_sigma = sigma + 1e-5;
-  real alpha = ((mu)/ c_sigma)^2;
-  real beta = (mu) / (c_sigma^2);
-  //account for numerical issues
-  alpha = alpha <= 0 ? 1e-5 : alpha;
-  beta = beta <= 0 ? 1e-5 : beta;
-  alpha = is_inf(alpha) ? 1e8 : alpha;
-  beta = is_inf(beta) ? 1e8 : beta; 
+  real small = 1e-5;
+  real large = 1e9;
+  real c_sigma = sigma < small ? small : sigma;
+  real c_mu = mu < small ? small : mu;
+  real alpha = ((c_mu) / c_sigma)^2;
+  real beta = (c_mu) / (c_sigma^2);
+  // account for numerical issues
+  alpha = alpha < small ? small : alpha;
+  alpha = alpha > large ? large : alpha;
+  beta = beta < small ? small : beta;
+  beta = beta > large ? large : beta;
   // calculate pmf
   trunc_pmf = gamma_cdf(max_val + 1, alpha, beta) - gamma_cdf(1, alpha, beta);
   for (i in 1:n){
@@ -26,8 +29,8 @@ vector discretised_lognormal_pmf(int[] y, real mu, real sigma, int max_val) {
   int n = num_elements(y);
   vector[n] pmf;
   real small = 1e-5;
-  real c_sigma = sigma <= 0 ? small : sigma;
-  real c_mu = mu <= 0 ? small : mu;
+  real c_sigma = sigma < small ? small : sigma;
+  real c_mu = mu < small ? small : mu;
   vector[n] adj_y = to_vector(y) + small;
   vector[n] upper_y = (log(adj_y + 1) - c_mu) / c_sigma;
   vector[n] lower_y = (log(adj_y) - c_mu) / c_sigma;


### PR DESCRIPTION
Make sure that all values of the parameters bellow a prespecified lower bound (`small = 1e-5`) or above a prescribed upper bound (`large = 1e9`) are clipped. Otherwise, the values in the range `0 - 1e-5` or `1e9 - Inf` are not limited.

For example, with `alpha = alpha <= 0 ? 1e-5 : alpha;`:
* if `alpha <= 0` → `alpha = 1e-5`
* if `alpha = 1e-500` → `alpha = 1e-500 < 1e-5`
* if `alpha = 1e-6` → `alpha = 1e-6 < 1e-5`
* if `alpha >= 1e-5` → `alpha >= 1e-5`

So, `0 < alpha < 1e-5` won't be clipped meaning that if `alpha = 1e-500`, `log(alpha) ~= -Inf`.

This PR fixes this behavior by clipping all values bellow the lower bound and above the upper bound. 
