### PR TITLE
stan: Remove trailing whitespaces

### DIFF
--- a/inst/stan/data/gaussian_process.stan
+++ b/inst/stan/data/gaussian_process.stan
@@ -2,7 +2,7 @@
   int<lower=1> M;			               // basis functions for infections gp
   real ls_meanlog;                   // meanlog for gp lengthscale prior
   real ls_sdlog;                     // sdlog for gp lengthscale prior
-  real<lower=0> ls_min;              // Lower bound for the lengthscale  
+  real<lower=0> ls_min;              // Lower bound for the lengthscale
   real<lower=0> ls_max;              // Upper bound for the lengthscale
   real alpha_sd;                     // standard deviation of the alpha gp kernal parameter
   int gp_type;                       // type of gp, 0 = squared exponential, 1 = 3/2 matern

--- a/inst/stan/data/rt.stan
+++ b/inst/stan/data/rt.stan
@@ -4,7 +4,7 @@
   real <lower = 0> r_mean;           // prior mean of reproduction number
   real <lower = 0> r_sd;             // prior standard deviation of reproduction number
   int bp_n;                          // no of breakpoints (0 = no breakpoints)
-  int breakpoints[t - seeding_time]; // when do breakpoints occur 
+  int breakpoints[t - seeding_time]; // when do breakpoints occur
   int future_fixed;                  // is underlying future Rt assumed to be fixed
   int fixed_from;                    // Reference date for when Rt estimation should be fixed
   int pop;                           // Initial susceptible population

--- a/inst/stan/data/simulation_observation_model.stan
+++ b/inst/stan/data/simulation_observation_model.stan
@@ -1,7 +1,7 @@
   int day_of_week[t - seeding_time]; // day of the week indicator (1 - 7)
   int week_effect;                   // should a day of the week effect be estimated
   real<lower = 0> day_of_week_simplex[n, week_effect ? 7 : 1];
-  int obs_scale; 
+  int obs_scale;
   real frac_obs[n, obs_scale];
   int model_type;
   real<lower = 0> rep_phi[n, model_type];  // overdispersion of the reporting process

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -25,10 +25,10 @@ transformed data{
   int ot_h = ot + horizon;  // observed time + forecast horizon
   // gaussian process
   int noise_terms = setup_noise(ot_h, t, horizon, estimate_r, stationary, future_fixed, fixed_from);
-  matrix[noise_terms, M] PHI = setup_gp(M, L, noise_terms);  // basis function 
+  matrix[noise_terms, M] PHI = setup_gp(M, L, noise_terms);  // basis function
   // Rt
-  real r_logmean = log(r_mean^2 / sqrt(r_sd^2 + r_mean^2)); 
-  real r_logsd = sqrt(log(1 + (r_sd^2 / r_mean^2))); 
+  real r_logmean = log(r_mean^2 / sqrt(r_sd^2 + r_mean^2));
+  real r_logsd = sqrt(log(1 + (r_sd^2 / r_mean^2)));
 }
 
 parameters{
@@ -38,7 +38,7 @@ parameters{
   vector[fixed ? 0 : M] eta;               // unconstrained noise
   // Rt
   vector[estimate_r] log_R;                // baseline reproduction number estimate (log)
-  real initial_infections[estimate_r] ;    // seed infections 
+  real initial_infections[estimate_r] ;    // seed infections
   real initial_growth[estimate_r && seeding_time > 1 ? 1 : 0]; // seed growth rate
   real<lower = 0, upper = max_gt> gt_mean[estimate_r]; // mean of generation time
   real<lower = 0> gt_sd[estimate_r];       // sd of generation time
@@ -47,7 +47,7 @@ parameters{
   // observation model
   real delay_mean[delays];                 // mean of delays
   real<lower = 0> delay_sd[delays];        // sd of delays
-  simplex[week_effect ? 7 : 1] day_of_week_simplex;   // day of week reporting effect 
+  simplex[week_effect ? 7 : 1] day_of_week_simplex;   // day of week reporting effect
   real<lower = 0> frac_obs[obs_scale];     // fraction of cases that are ultimately observed
   real truncation_mean[truncation];        // mean of truncation
   real<lower = 0> truncation_sd[truncation]; // sd of truncation
@@ -85,20 +85,20 @@ transformed parameters {
  if (obs_scale) {
    reports = scale_obs(reports, frac_obs[1]);
  }
- // truncate near time cases to observed reports 
+ // truncate near time cases to observed reports
  obs_reports = truncate(reports[1:ot], truncation_mean, truncation_sd, max_truncation, 0);
 }
 
 model {
   // priors for noise GP
   if (!fixed) {
-    gaussian_process_lp(rho[1], alpha[1], eta, ls_meanlog, 
+    gaussian_process_lp(rho[1], alpha[1], eta, ls_meanlog,
                         ls_sdlog, ls_min, ls_max, alpha_sd);
   }
   // penalised priors for delay distributions
   delays_lp(delay_mean, delay_mean_mean, delay_mean_sd, delay_sd, delay_sd_mean, delay_sd_sd, t);
   // priors for truncation
-  truncation_lp(truncation_mean, truncation_sd, trunc_mean_mean, trunc_mean_sd, 
+  truncation_lp(truncation_mean, truncation_sd, trunc_mean_mean, trunc_mean_sd,
                 trunc_sd_mean, trunc_sd_sd);
   if (estimate_r) {
     // priors on Rt
@@ -114,9 +114,9 @@ model {
   // observed reports from mean of reports (update likelihood)
   report_lp(cases, obs_reports, rep_phi, 1, model_type, obs_weight);
 }
-  
+
 generated quantities {
-  int imputed_reports[ot_h]; 
+  int imputed_reports[ot_h];
   vector[estimate_r > 0 ? 0: ot_h] gen_R;
   real r[ot_h];
   vector[ot] log_lik;
@@ -128,7 +128,7 @@ generated quantities {
     real gt_mean_sample = normal_rng(gt_mean_mean, gt_mean_sd);
     real gt_sd_sample = normal_rng(gt_sd_mean, gt_sd_sd);
     // calculate Rt using infections and generation time
-    gen_R = calculate_Rt(infections, seeding_time, gt_mean_sample, gt_mean_sample, 
+    gen_R = calculate_Rt(infections, seeding_time, gt_mean_sample, gt_mean_sample,
                          max_gt, rt_half_window);
     // estimate growth from calculated Rt
     r = R_to_growth(gen_R, gt_mean_sample, gt_sd_sample);

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -5,7 +5,7 @@ functions {
 #include functions/secondary.stan
 }
 
-data { 
+data {
   int t;                             // time of observations
   int<lower = 0> obs[t];             // observed secondary data
   vector[t] primary;                 // observed primary data
@@ -19,7 +19,7 @@ parameters{
   // observation model
   real delay_mean[delays];               // mean of delays
   real<lower = 0> delay_sd[delays];      // sd of delays
-  simplex[week_effect ? 7 : 1] day_of_week_simplex;   // day of week reporting effect 
+  simplex[week_effect ? 7 : 1] day_of_week_simplex;   // day of week reporting effect
   real<lower = 0> frac_obs[obs_scale];   // fraction of cases that are ultimately observed
   real truncation_mean[truncation];      // mean of truncation
   real truncation_sd[truncation];        // sd of truncation
@@ -29,15 +29,15 @@ parameters{
 transformed parameters {
   vector<lower=0>[t] secondary;
   // calculate secondary reports from primary
-  secondary = calculate_secondary(primary, obs, frac_obs, delay_mean, 
-                                  delay_sd, max_delay, cumulative, 
-                                  historic, primary_hist_additive, 
+  secondary = calculate_secondary(primary, obs, frac_obs, delay_mean,
+                                  delay_sd, max_delay, cumulative,
+                                  historic, primary_hist_additive,
                                   current, primary_current_additive, t);
  // weekly reporting effect
  if (week_effect) {
    secondary = day_of_week_effect(secondary, day_of_week, day_of_week_simplex);
   }
- // truncate near time cases to observed reports 
+ // truncate near time cases to observed reports
  secondary = truncate(secondary, truncation_mean, truncation_sd, max_truncation, 0);
 }
 
@@ -45,7 +45,7 @@ model {
   // penalised priors for delay distributions
   delays_lp(delay_mean, delay_mean_mean, delay_mean_sd, delay_sd, delay_sd_mean, delay_sd_sd, 1);
   // priors for truncation
-  truncation_lp(truncation_mean, truncation_sd, trunc_mean_mean, trunc_mean_sd, 
+  truncation_lp(truncation_mean, truncation_sd, trunc_mean_mean, trunc_mean_sd,
                 trunc_sd_mean, trunc_sd_sd);
   // prior primary report scaling
   if (obs_scale) {
@@ -54,9 +54,9 @@ model {
   // observed secondary reports from mean of secondary reports (update likelihood)
   report_lp(obs[(burn_in + 1):t], secondary[(burn_in + 1):t], rep_phi, 1, model_type, 1);
 }
-  
+
 generated quantities {
-  int sim_secondary[t - burn_in]; 
+  int sim_secondary[t - burn_in];
   vector[t - burn_in] log_lik;
   // simulate secondary reports
   sim_secondary = report_rng(secondary[(burn_in + 1):t], rep_phi, model_type);

--- a/inst/stan/functions/convolve.stan
+++ b/inst/stan/functions/convolve.stan
@@ -1,4 +1,4 @@
-// convolve a pdf and case vector 
+// convolve a pdf and case vector
 vector convolve(vector cases, vector rev_pmf) {
     int t = num_elements(cases);
     int max_pmf = num_elements(rev_pmf);
@@ -12,8 +12,8 @@ vector convolve(vector cases, vector rev_pmf) {
 
 
 // convolve latent infections to reported (but still unobserved) cases
-vector convolve_to_report(vector infections, 
-                          real[] delay_mean, 
+vector convolve_to_report(vector infections,
+                          real[] delay_mean,
                           real[] delay_sd,
                           int[] max_delay,
                           int seeding_time) {
@@ -39,7 +39,7 @@ vector convolve_to_report(vector infections,
   return(reports);
 }
 
-void delays_lp(real[] delay_mean, real[] delay_mean_mean, real[] delay_mean_sd, 
+void delays_lp(real[] delay_mean, real[] delay_mean_mean, real[] delay_mean_sd,
                real[] delay_sd, real[] delay_sd_mean, real[] delay_sd_sd, int weight){
     int delays = num_elements(delay_mean);
     if (delays) {

--- a/inst/stan/functions/gaussian_process.stan
+++ b/inst/stan/functions/gaussian_process.stan
@@ -11,7 +11,7 @@ vector phi(real L, int m, vector x) {
   vector[rows(x)] fi;
   fi = 1/sqrt(L) * sin(m*pi()/(2*L) * (x+L));
   return fi;
-}	
+}
 // spectral density of the exponential quadratic kernal
 real spd_se(real alpha, real rho, real w) {
   real S;
@@ -25,10 +25,10 @@ real spd_matern(real alpha, real rho, real w) {
   return S;
 }
 // setup gaussian process noise dimensions
-int setup_noise(int ot_h, int t, int horizon, int estimate_r, 
+int setup_noise(int ot_h, int t, int horizon, int estimate_r,
                 int stationary, int future_fixed, int fixed_from) {
   int noise_time = estimate_r > 0 ? (stationary > 0 ? ot_h : ot_h - 1) : t;
-  int noise_terms =  future_fixed > 0 ? (noise_time - horizon + fixed_from) : noise_time; 
+  int noise_terms =  future_fixed > 0 ? (noise_time - horizon + fixed_from) : noise_time;
   return(noise_terms);
 }
 // setup approximate gaussian process
@@ -39,13 +39,13 @@ matrix setup_gp(int M, real L, int dimension) {
   for (s in 1:dimension) {
     time[s] = (s - half_dim) / half_dim;
   }
-  for (m in 1:M){ 
-    PHI[,m] = phi(L, m, time); 
+  for (m in 1:M){
+    PHI[,m] = phi(L, m, time);
   }
   return(PHI);
 }
 // update gaussian process using spectral densities
-vector update_gp(matrix PHI, int M, real L, real alpha, 
+vector update_gp(matrix PHI, int M, real L, real alpha,
                  real rho, vector eta, int type) {
   vector[M] diagSPD;    // spectral density
   vector[M] SPD_eta;    // spectral density * noise
@@ -54,12 +54,12 @@ vector update_gp(matrix PHI, int M, real L, real alpha,
   real unit_rho = rho / noise_terms;
   // GP in noise - spectral densities
   if (type == 0) {
-    for(m in 1:M){ 
-      diagSPD[m] =  sqrt(spd_se(alpha, unit_rho, sqrt(lambda(L, m)))); 
+    for(m in 1:M){
+      diagSPD[m] =  sqrt(spd_se(alpha, unit_rho, sqrt(lambda(L, m))));
     }
   }else if (type == 1) {
-    for(m in 1:M){ 
-      diagSPD[m] =  sqrt(spd_matern(alpha, unit_rho, sqrt(lambda(L, m)))); 
+    for(m in 1:M){
+      diagSPD[m] =  sqrt(spd_matern(alpha, unit_rho, sqrt(lambda(L, m))));
     }
   }
   SPD_eta = diagSPD .* eta;

--- a/inst/stan/functions/generated_quantities.stan
+++ b/inst/stan/functions/generated_quantities.stan
@@ -2,13 +2,13 @@
 vector calculate_Rt(vector infections, int seeding_time,
                     real gt_mean, real gt_sd, int max_gt,
                     int smooth) {
-  vector[max_gt] gt_pmf;  
+  vector[max_gt] gt_pmf;
   int gt_indexes[max_gt];
   int t = num_elements(infections);
   int ot = t - seeding_time;
   vector[ot] R;
   vector[ot] sR;
-  vector[ot] infectiousness = rep_vector(1e-5, ot); 
+  vector[ot] infectiousness = rep_vector(1e-5, ot);
   // calculate PMF of the generation time
   for (i in 1:(max_gt)) {
     gt_indexes[i] = max_gt - i + 1;
@@ -41,6 +41,6 @@ real[] R_to_growth(vector R, real gt_mean, real gt_sd) {
   real r[t];
   for (s in 1:t) {
     r[s] = (pow(R[s], k) - 1) / (k * gt_mean);
-  } 
+  }
   return(r);
 }

--- a/inst/stan/functions/infections.stan
+++ b/inst/stan/functions/infections.stan
@@ -9,7 +9,7 @@ real update_infectiousness(vector infections, vector gt_pmf,
   return(new_inf);
 }
 // generate infections by using Rt = Rt-1 * sum(reversed generation time pmf * infections)
-vector generate_infections(vector oR, int uot, 
+vector generate_infections(vector oR, int uot,
                            real[] gt_mean, real[] gt_sd, int max_gt,
                            real[] initial_infections, real[] initial_growth,
                            int pop, int ht) {
@@ -23,7 +23,7 @@ vector generate_infections(vector oR, int uot,
   vector[ot] cum_infections = rep_vector(0, ot);
   vector[ot] infectiousness = rep_vector(1e-5, ot);
   // generation time pmf
-  vector[max_gt] gt_pmf = rep_vector(1e-5, max_gt);   
+  vector[max_gt] gt_pmf = rep_vector(1e-5, max_gt);
   int gt_indexes[max_gt];
   for (i in 1:(max_gt)) {
     gt_indexes[i] = max_gt - i + 1;
@@ -66,7 +66,7 @@ vector deconvolve_infections(vector shifted_cases, vector noise, int fixed,
     if (prior == 1) {
       infections = infections + shifted_cases .* exp_noise;
     }else if (prior == 0) {
-     infections = infections + exp_noise; 
+     infections = infections + exp_noise;
     }else if (prior == 2) {
       infections[1] = infections[1] + shifted_cases[1] * exp_noise[1];
       for (i in 2:t) {
@@ -79,7 +79,7 @@ vector deconvolve_infections(vector shifted_cases, vector noise, int fixed,
   return(infections);
 }
 // Update the log density for the generation time distribution mean and sd
-void generation_time_lp(real[] gt_mean, real gt_mean_mean, real gt_mean_sd, 
+void generation_time_lp(real[] gt_mean, real gt_mean_mean, real gt_mean_sd,
                         real[] gt_sd, real gt_sd_mean, real gt_sd_sd, int weight) {
     target += normal_lpdf(gt_mean[1] | gt_mean_mean, gt_mean_sd) * weight;
     target += normal_lpdf(gt_sd[1] | gt_sd_mean, gt_sd_sd) * weight;

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -10,7 +10,7 @@ vector day_of_week_effect(vector reports, int[] day_of_week, vector effect) {
    }
   return(scaled_reports);
 }
-// Scale observations by fraction reported and update log density of 
+// Scale observations by fraction reported and update log density of
 // fraction reported
 vector scale_obs(vector reports, real frac_obs) {
   int t = num_elements(reports);
@@ -25,14 +25,14 @@ vector truncation_cmf(real trunc_mean, real trunc_sd, int trunc_max) {
     for (i in 1:(trunc_max)) {
       trunc_indexes[i] = i - 1;
     }
-    cmf = discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max);   
+    cmf = discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max);
     cmf[1] = cmf[1] + 1e-8;
     cmf = cumulative_sum(cmf);
     cmf = reverse_mf(cmf, trunc_max);
     return(cmf);
 }
 // Truncate observed data by some truncation distribution
-vector truncate(vector reports, real[] truncation_mean, real[] truncation_sd, 
+vector truncate(vector reports, real[] truncation_mean, real[] truncation_sd,
                 int[] truncation_max, int reconstruct) {
   int t = num_elements(reports);
   int truncation = num_elements(truncation_mean);
@@ -54,17 +54,17 @@ vector truncate(vector reports, real[] truncation_mean, real[] truncation_sd,
   return(trunc_reports);
 }
 // Truncation distribution priors
-void truncation_lp(real[] truncation_mean, real[] truncation_sd, 
-                   real[] trunc_mean_mean, real[] trunc_mean_sd, 
+void truncation_lp(real[] truncation_mean, real[] truncation_sd,
+                   real[] trunc_mean_mean, real[] trunc_mean_sd,
                    real[] trunc_sd_mean, real[] trunc_sd_sd) {
   int truncation = num_elements(truncation_mean);
   if (truncation) {
     truncation_mean ~ normal(trunc_mean_mean, trunc_mean_sd);
     truncation_sd ~ normal(trunc_sd_mean, trunc_sd_sd);
-  }                     
+  }
 }
 // update log density for reported cases
-void report_lp(int[] cases, vector reports, 
+void report_lp(int[] cases, vector reports,
                real[] rep_phi, int phi_prior,
                int model_type, real weight) {
   real sqrt_phi;
@@ -83,7 +83,7 @@ void report_lp(int[] cases, vector reports,
   }
 }
 // update log likelihood (as above but not vectorised and returning log likelihood)
-vector report_log_lik(int[] cases, vector reports, 
+vector report_log_lik(int[] cases, vector reports,
                       real[] rep_phi, int model_type, real weight) {
     int t = num_elements(reports);
     vector[t] log_lik;

--- a/inst/stan/functions/pmfs.stan
+++ b/inst/stan/functions/pmfs.stan
@@ -18,7 +18,7 @@ vector discretised_gamma_pmf(int[] y, real mu, real sigma, int max_val) {
   // calculate pmf
   trunc_pmf = gamma_cdf(max_val + 1, alpha, beta) - gamma_cdf(1, alpha, beta);
   for (i in 1:n){
-    pmf[i] = (gamma_cdf(y[i] + 1, alpha, beta) - gamma_cdf(y[i], alpha, beta)) / 
+    pmf[i] = (gamma_cdf(y[i] + 1, alpha, beta) - gamma_cdf(y[i], alpha, beta)) /
     trunc_pmf;
   }
   return(pmf);

--- a/inst/stan/functions/rt.stan
+++ b/inst/stan/functions/rt.stan
@@ -41,7 +41,7 @@ vector update_Rt(vector input_R, real log_R, vector noise, int[] bps,
 // Rt priors
 void rt_lp(vector log_R, real[] initial_infections, real[] initial_growth,
            real[] bp_effects, real[] bp_sd, int bp_n, int seeding_time,
-           real r_logmean, real r_logsd, real prior_infections, 
+           real r_logmean, real r_logsd, real prior_infections,
            real prior_growth) {
   // prior on R
   log_R ~ normal(r_logmean, r_logsd);

--- a/inst/stan/functions/secondary.stan
+++ b/inst/stan/functions/secondary.stan
@@ -7,9 +7,9 @@ vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
   int t = num_elements(reports);
   int obs_scale = num_elements(frac_obs);
   vector[t] scaled_reports;
-  vector[t] conv_reports = rep_vector(1e-5, t);                            
+  vector[t] conv_reports = rep_vector(1e-5, t);
   vector[t] secondary_reports = rep_vector(0.0, t);
-  // scaling of reported cases by fraction 
+  // scaling of reported cases by fraction
   if (obs_scale) {
     scaled_reports = scale_obs(reports, frac_obs[1]);
   }else{
@@ -24,7 +24,7 @@ vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
     // update cumulative target
     if (cumulative && i > 1) {
       if (i > predict) {
-        secondary_reports[i] = secondary_reports[i - 1];       
+        secondary_reports[i] = secondary_reports[i - 1];
       }else{
         secondary_reports[i] = obs[i - 1];
       }

--- a/inst/stan/simulate_infections.stan
+++ b/inst/stan/simulate_infections.stan
@@ -30,16 +30,16 @@ generated quantities {
   real r[n, t - seeding_time];
   for (i in 1:n) {
     // generate infections from Rt trace
-    infections[i] = to_row_vector(generate_infections(to_vector(R[i]), seeding_time, 
-                                                      gt_mean[i], gt_sd[i], max_gt, 
+    infections[i] = to_row_vector(generate_infections(to_vector(R[i]), seeding_time,
+                                                      gt_mean[i], gt_sd[i], max_gt,
                                                       initial_infections[i], initial_growth[i],
                                                       pop, future_time));
     // convolve from latent infections to mean of observations
-    reports[i] = to_row_vector(convolve_to_report(to_vector(infections[i]), delay_mean[i], 
+    reports[i] = to_row_vector(convolve_to_report(to_vector(infections[i]), delay_mean[i],
                                                   delay_sd[i], max_delay, seeding_time));
-    // weekly reporting effect 
+    // weekly reporting effect
     if (week_effect) {
-      reports[i] = to_row_vector(day_of_week_effect(to_vector(reports[i]), day_of_week, 
+      reports[i] = to_row_vector(day_of_week_effect(to_vector(reports[i]), day_of_week,
                                                     to_vector(day_of_week_simplex[i])));
     }
     // scale observations

--- a/inst/stan/simulate_secondary.stan
+++ b/inst/stan/simulate_secondary.stan
@@ -5,7 +5,7 @@ functions {
 #include functions/secondary.stan
 }
 
-data {  
+data {
   // dimensions
   int n; // number of samples
   int t; // time
@@ -16,20 +16,20 @@ data {
   matrix[n, t] primary;              // observed primary data
 #include data/secondary.stan
   // delay from infection to report
-#include data/simulation_delays.stan  
+#include data/simulation_delays.stan
   // observation model
 #include data/simulation_observation_model.stan
 }
 
 generated quantities {
-  int sim_secondary[n, all_dates ? t : h]; 
+  int sim_secondary[n, all_dates ? t : h];
   for (i in 1:n) {
     vector[t] secondary;
     // calculate secondary reports from primary
-    secondary = 
-       calculate_secondary(to_vector(primary[i]), obs, frac_obs[i], delay_mean[i], 
-                           delay_sd[i], max_delay, cumulative, 
-                           historic, primary_hist_additive, 
+    secondary =
+       calculate_secondary(to_vector(primary[i]), obs, frac_obs[i], delay_mean[i],
+                           delay_sd[i], max_delay, cumulative,
+                           historic, primary_hist_additive,
                            current, primary_current_additive, t - h + 1);
     // weekly reporting effect
     if (week_effect) {

--- a/inst/stan/tune_inv_gamma.stan
+++ b/inst/stan/tune_inv_gamma.stan
@@ -23,15 +23,15 @@ data {
 
 transformed data {
   vector[2] theta = [l, u]';
-    
+
   real delta = 1;
   real a = square(delta * (u + l) / (u - l)) + 2;
   real b =  ((u + l) / 2) * (square(delta * (u + l) / (u - l)) + 1);
   vector[2] y_guess = [log(a), log(b)]';
-  
+
   real x_r[0];
   int x_i[0];
-  
+
   vector[2] y = algebra_solver(tail_delta, y_guess, theta, x_r, x_i);
 }
 


### PR DESCRIPTION
A quick test of the C++ code generated by `rstan` and processing it by `stanc3` returns the following error:
```
    Semantic error in 'string', line 326, column 68 to column 78:

    Identifier 'delay_mean' not in scope.
```

After debugging, I found that the trailing whitespaces at https://github.com/epiforecasts/EpiNow2/blob/0689b1e7e1350c7bec8802adf098f270d1b30a9c/inst/stan/simulate_secondary.stan#L19 caused a parsing issue that excluded `simulation_delays.stan`.

So, let's clean it up everywhere!

Here's the full/expanded `stan` code for the `simulate_secondary` as generated by `rstan`/`rstantools` (note that at line 310, after `// delay from infection to report`, the declarations from `simulation_delays.stan` are missing!):
```
functions {
// discretised truncated gamma pmf
vector discretised_gamma_pmf(int[] y, real mu, real sigma, int max_val) {
  int n = num_elements(y);
  vector[n] pmf;
  real trunc_pmf;
  // calculate alpha and beta for gamma distribution
  real small = 1e-5;
  real large = 1e8;
  real c_sigma = sigma < small ? small : sigma;
  real c_mu = mu < small ? small : mu;
  real alpha = ((c_mu) / c_sigma)^2;
  real beta = (c_mu) / (c_sigma^2);
  // account for numerical issues
  alpha = alpha < small ? small : alpha;
  alpha = alpha > large ? large : alpha;
  beta = beta < small ? small : beta;
  beta = beta > large ? large : beta;
  // calculate pmf
  trunc_pmf = gamma_cdf(max_val + 1, alpha, beta) - gamma_cdf(1, alpha, beta);
  for (i in 1:n){
    pmf[i] = (gamma_cdf(y[i] + 1, alpha, beta) - gamma_cdf(y[i], alpha, beta)) /
    trunc_pmf;
  }
  return(pmf);
}

// discretised truncated lognormal pmf
vector discretised_lognormal_pmf(int[] y, real mu, real sigma, int max_val) {
  int n = num_elements(y);
  vector[n] pmf;
  real small = 1e-5;
  real c_sigma = sigma < small ? small : sigma;
  real c_mu = mu < small ? small : mu;
  vector[n] adj_y = to_vector(y) + small;
  vector[n] upper_y = (log(adj_y + 1) - c_mu) / c_sigma;
  vector[n] lower_y = (log(adj_y) - c_mu) / c_sigma;
  real max_cdf = normal_cdf((log(max_val + small) - c_mu) / c_sigma, 0.0, 1.0);
  real min_cdf = normal_cdf((log(small) - c_mu) / c_sigma, 0.0, 1.0);
  real trunc_cdf = max_cdf - min_cdf;
  for (i in 1:n) {
    pmf[i] = (normal_cdf(upper_y[i], 0.0, 1.0) - normal_cdf(lower_y[i], 0.0, 1.0)) /
    trunc_cdf;
  }
  return(pmf);
}

// reverse a mf
vector reverse_mf(vector pmf, int max_pmf) {
  vector[max_pmf] rev_pmf;
  for (d in 1:max_pmf) {
    rev_pmf[d] = pmf[max_pmf - d + 1];
  }
  return rev_pmf;
}
// convolve a pdf and case vector
vector convolve(vector cases, vector rev_pmf) {
    int t = num_elements(cases);
    int max_pmf = num_elements(rev_pmf);
    vector[t] conv_cases = rep_vector(1e-5, t);
    for (s in 1:t) {
        conv_cases[s] += dot_product(cases[max(1, (s - max_pmf + 1)):s],
                                     tail(rev_pmf, min(max_pmf, s)));
    }
   return(conv_cases);
  }


// convolve latent infections to reported (but still unobserved) cases
vector convolve_to_report(vector infections,
                          real[] delay_mean,
                          real[] delay_sd,
                          int[] max_delay,
                          int seeding_time) {
  int t = num_elements(infections);
  vector[t - seeding_time] reports;
  vector[t] unobs_reports = infections;
  int delays = num_elements(delay_mean);
  if (delays) {
    for (s in 1:delays) {
      vector[max_delay[s]] pmf = rep_vector(1e-5, max_delay[s]);
      int delay_indexes[max_delay[s]];
      for (i in 1:max_delay[s]) {
        delay_indexes[i] = max_delay[s] - i;
      }
      pmf = pmf + discretised_lognormal_pmf(delay_indexes, delay_mean[s],
                                            delay_sd[s], max_delay[s]);
      unobs_reports = convolve(unobs_reports, pmf);
    }
    reports = unobs_reports[(seeding_time + 1):t];
  }else{
    reports = infections[(seeding_time + 1):t];
  }
  return(reports);
}

void delays_lp(real[] delay_mean, real[] delay_mean_mean, real[] delay_mean_sd,
               real[] delay_sd, real[] delay_sd_mean, real[] delay_sd_sd, int weight){
    int delays = num_elements(delay_mean);
    if (delays) {
    for (s in 1:delays) {
      target += normal_lpdf(delay_mean[s] | delay_mean_mean[s], delay_mean_sd[s]) * weight;
      target += normal_lpdf(delay_sd[s] | delay_sd_mean[s], delay_sd_sd[s]) * weight;
    }
  }
}
// apply day of the week effect
vector day_of_week_effect(vector reports, int[] day_of_week, vector effect) {
  int t = num_elements(reports);
  // scale day of week effect
  vector[7] scaled_effect = 7 * effect;
  vector[t] scaled_reports;
  for (s in 1:t) {
    // add reporting effects (adjust for simplex scale)
    scaled_reports[s] = reports[s] * scaled_effect[day_of_week[s]];
   }
  return(scaled_reports);
}
// Scale observations by fraction reported and update log density of
// fraction reported
vector scale_obs(vector reports, real frac_obs) {
  int t = num_elements(reports);
  vector[t] scaled_reports;
  scaled_reports = reports * frac_obs;
  return(scaled_reports);
}
// Calculate a truncation CMF
vector truncation_cmf(real trunc_mean, real trunc_sd, int trunc_max) {
    int  trunc_indexes[trunc_max];
    vector[trunc_max] cmf;
    for (i in 1:(trunc_max)) {
      trunc_indexes[i] = i - 1;
    }
    cmf = discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max);
    cmf[1] = cmf[1] + 1e-8;
    cmf = cumulative_sum(cmf);
    cmf = reverse_mf(cmf, trunc_max);
    return(cmf);
}
// Truncate observed data by some truncation distribution
vector truncate(vector reports, real[] truncation_mean, real[] truncation_sd,
                int[] truncation_max, int reconstruct) {
  int t = num_elements(reports);
  int truncation = num_elements(truncation_mean);
  vector[t] trunc_reports = reports;
  if (truncation) {
    // Calculate cmf of truncation delay
    int trunc_max = truncation_max[1] > t ? t : truncation_max[1];
    int  trunc_indexes[trunc_max];
    vector[trunc_max] cmf;
    int first_t = t - trunc_max + 1;
    cmf = truncation_cmf(truncation_mean[1], truncation_sd[1], trunc_max);
    // Apply cdf of truncation delay to truncation max last entries in reports
    if (reconstruct) {
      trunc_reports[first_t:t] = trunc_reports[first_t:t] ./ cmf;
    }else{
      trunc_reports[first_t:t] = trunc_reports[first_t:t] .* cmf;
    }
  }
  return(trunc_reports);
}
// Truncation distribution priors
void truncation_lp(real[] truncation_mean, real[] truncation_sd,
                   real[] trunc_mean_mean, real[] trunc_mean_sd,
                   real[] trunc_sd_mean, real[] trunc_sd_sd) {
  int truncation = num_elements(truncation_mean);
  if (truncation) {
    truncation_mean ~ normal(trunc_mean_mean, trunc_mean_sd);
    truncation_sd ~ normal(trunc_sd_mean, trunc_sd_sd);
  }
}
// update log density for reported cases
void report_lp(int[] cases, vector reports,
               real[] rep_phi, int phi_prior,
               int model_type, real weight) {
  real sqrt_phi;
  if (model_type) {
    // the reciprocal overdispersion parameter (phi)
    rep_phi[model_type] ~ normal(0, phi_prior) T[0,];
    sqrt_phi = 1 / sqrt(rep_phi[model_type]);
    // defer to poisson if phi is large, to avoid overflow
    if (sqrt_phi > 1e4) {
      target += poisson_lpmf(cases | reports) * weight;
    } else {
      target += neg_binomial_2_lpmf(cases | reports, sqrt_phi) * weight;
    }
  } else {
    target += poisson_lpmf(cases | reports) * weight;
  }
}
// update log likelihood (as above but not vectorised and returning log likelihood)
vector report_log_lik(int[] cases, vector reports,
                      real[] rep_phi, int model_type, real weight) {
    int t = num_elements(reports);
    vector[t] log_lik;
    if (model_type) {
    // the reciprocal overdispersion parameter (phi)
    real sqrt_phi = 1 / sqrt(rep_phi[model_type]);
    // defer to poisson if phi is large, to avoid overflow
    if (sqrt_phi > 1e4) {
      for (i in 1:t) {
        log_lik[i] = poisson_lpmf(cases[i] | reports[i]) * weight;
      }
    } else {
      for (i in 1:t) {
        log_lik[i] = neg_binomial_2_lpmf(cases[i] | reports[i], sqrt_phi) * weight;
      }
    }
  } else {
    for (i in 1:t) {
      log_lik[i] = poisson_lpmf(cases[i] | reports[i]) * weight;
    }
  }
  return(log_lik);
}
// sample reported cases from the observation model
int[] report_rng(vector reports, real[] rep_phi, int model_type) {
  int t = num_elements(reports);
  int sampled_reports[t];
  real sqrt_phi;
  if (model_type) {
    sqrt_phi = 1 / sqrt(rep_phi[model_type]);
    for (s in 1:t) {
      // defer to poisson if phi is large, to avoid overflow
      if (sqrt_phi > 1e4) {
        sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
      } else {
        sampled_reports[s] = neg_binomial_2_rng(reports[s] > 1e8 ? 1e8 : reports[s], sqrt_phi);
      }
    }
  }else {
    for (s in 1:t) {
      sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
    }
  }
  return(sampled_reports);
}


// Calculate secondary reports condition only on primary reports
vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
                           real[] delay_mean, real[] delay_sd,
                           int[] max_delay, int cumulative, int historic,
                           int primary_hist_additive, int current,
                           int primary_current_additive, int predict) {
  int t = num_elements(reports);
  int obs_scale = num_elements(frac_obs);
  vector[t] scaled_reports;
  vector[t] conv_reports = rep_vector(1e-5, t);
  vector[t] secondary_reports = rep_vector(0.0, t);
  // scaling of reported cases by fraction
  if (obs_scale) {
    scaled_reports = scale_obs(reports, frac_obs[1]);
  }else{
    scaled_reports = reports;
  }
  // convolve from reports to contributions from these reports
  conv_reports =
    conv_reports + convolve_to_report(scaled_reports, delay_mean, delay_sd, max_delay, 0);
  // if predicting and using a cumulative target
  // combine reports with previous secondary data
  for (i in 1:t) {
    // update cumulative target
    if (cumulative && i > 1) {
      if (i > predict) {
        secondary_reports[i] = secondary_reports[i - 1];
      }else{
        secondary_reports[i] = obs[i - 1];
      }
    }
    // update based on previous primary reports
    if (historic) {
      if (primary_hist_additive) {
      secondary_reports[i] += conv_reports[i];
      }else{
        if (conv_reports[i] > secondary_reports[i]) {
          conv_reports[i] = secondary_reports[i];
        }
      secondary_reports[i] -= conv_reports[i];
      }
    }
    // update based on current primary reports
    if (current) {
      if (primary_current_additive) {
        secondary_reports[i] += scaled_reports[i];
      }else{
        secondary_reports[i] -= scaled_reports[i];
      }
    }
    secondary_reports[i] = secondary_reports[i] <= 0 ? 1e-5 : secondary_reports[i];
  }
  return(secondary_reports);
}
}
data {
  // dimensions
  int n; // number of samples
  int t; // time
  int h; // forecast horizon
  int all_dates; // should all dates have simulations returned
  // secondary model specific data
  int<lower = 0> obs[t - h];         // observed secondary data
  matrix[n, t] primary;              // observed primary data
  int seeding_time;                  // required for setting up observation model
  int cumulative;                    // Should secondary reports be cumulative
  int historic;                      // Should primary historic reports be considered
  int primary_hist_additive;         // Should historic primary reports be additive
  int current;                       // Should current primary reports be considered
  int primary_current_additive;      // Should current primary reports be additive
  // delay from infection to report
  // observation model
  int day_of_week[t - seeding_time]; // day of the week indicator (1 - 7)
  int week_effect;                   // should a day of the week effect be estimated
  real<lower = 0> day_of_week_simplex[n, week_effect ? 7 : 1];
  int obs_scale;
  real frac_obs[n, obs_scale];
  int model_type;
  real<lower = 0> rep_phi[n, model_type];  // overdispersion of the reporting process
}
generated quantities {
  int sim_secondary[n, all_dates ? t : h];
  for (i in 1:n) {
    vector[t] secondary;
    // calculate secondary reports from primary
    secondary =
       calculate_secondary(to_vector(primary[i]), obs, frac_obs[i], delay_mean[i],
                           delay_sd[i], max_delay, cumulative,
                           historic, primary_hist_additive,
                           current, primary_current_additive, t - h + 1);
    // weekly reporting effect
    if (week_effect) {
      secondary = day_of_week_effect(secondary, day_of_week, to_vector(day_of_week_simplex[i]));
    }
    // simulate secondary reports
    sim_secondary[i] = report_rng(tail(secondary, all_dates ? t : h), rep_phi[i], model_type);
  }
}
```