### PR TITLE
Update growth calculation

### DIFF
--- a/R/extract.R
+++ b/R/extract.R
@@ -119,7 +119,7 @@ extract_parameter_samples <- function(stan_fit, data, reported_dates, reported_i
   out$growth_rate <- extract_parameter(
     "r",
     samples,
-    reported_dates
+    reported_dates[-1]
   )
   if (data$week_effect == 1) {
     out$day_of_week <- extract_parameter(

--- a/R/stanmodels.R
+++ b/R/stanmodels.R
@@ -17,22 +17,17 @@ Rcpp::loadModule("stan_fit4tune_inv_gamma_mod", what = TRUE)
 # instantiate each stanmodel object
 stanmodels <- sapply(stanmodels, function(model_name) {
   # create C++ code for stan model
-  stan_file <- if (dir.exists("stan")) "stan" else file.path("inst", "stan")
+  stan_file <- if(dir.exists("stan")) "stan" else file.path("inst", "stan")
   stan_file <- file.path(stan_file, paste0(model_name, ".stan"))
   stanfit <- rstan::stanc_builder(stan_file,
-    allow_undefined = TRUE,
-    obfuscate_model_name = FALSE
-  )
-  stanfit$model_cpp <- list(
-    model_cppname = stanfit$model_name,
-    model_cppcode = stanfit$cppcode
-  )
+                                  allow_undefined = TRUE,
+                                  obfuscate_model_name = FALSE)
+  stanfit$model_cpp <- list(model_cppname = stanfit$model_name,
+                            model_cppcode = stanfit$cppcode)
   # create stanmodel object
-  methods::new(
-    Class = "stanmodel",
-    model_name = stanfit$model_name,
-    model_code = stanfit$model_code,
-    model_cpp = stanfit$model_cpp,
-    mk_cppmodule = function(x) get(paste0("model_", model_name))
-  )
+  methods::new(Class = "stanmodel",
+               model_name = stanfit$model_name,
+               model_code = stanfit$model_code,
+               model_cpp = stanfit$model_cpp,
+               mk_cppmodule = function(x) get(paste0("model_", model_name)))
 })

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -120,19 +120,16 @@ generated quantities {
   vector[estimate_r > 0 ? 0: ot_h] gen_R;
   real r[ot_h];
   vector[ot] log_lik;
-  if (estimate_r){
-    // estimate growth from estimated Rt
-    r = R_to_growth(R, gt_mean[1], gt_sd[1]);
-  }else{
+  if (estimate_r == 0){
     // sample generation time
     real gt_mean_sample = normal_rng(gt_mean_mean, gt_mean_sd);
     real gt_sd_sample = normal_rng(gt_sd_mean, gt_sd_sd);
     // calculate Rt using infections and generation time
     gen_R = calculate_Rt(infections, seeding_time, gt_mean_sample, gt_mean_sample,
                          max_gt, rt_half_window);
-    // estimate growth from calculated Rt
-    r = R_to_growth(gen_R, gt_mean_sample, gt_sd_sample);
   }
+  // estimate growth from infections
+  r = calculate_growth(infections, seeding_time);
   // simulate reported cases
   imputed_reports = report_rng(reports, rep_phi, model_type);
   // log likelihood of model

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -118,7 +118,7 @@ model {
 generated quantities {
   int imputed_reports[ot_h];
   vector[estimate_r > 0 ? 0: ot_h] gen_R;
-  real r[ot_h];
+  real r[ot_h - 1];
   vector[ot] log_lik;
   if (estimate_r == 0){
     // sample generation time
@@ -129,7 +129,7 @@ generated quantities {
                          max_gt, rt_half_window);
   }
   // estimate growth from infections
-  r = calculate_growth(infections, seeding_time);
+  r = calculate_growth(infections, seeding_time + 1);
   // simulate reported cases
   imputed_reports = report_rng(reports, rep_phi, model_type);
   // log likelihood of model

--- a/inst/stan/functions/generated_quantities.stan
+++ b/inst/stan/functions/generated_quantities.stan
@@ -49,6 +49,6 @@ real[] calculate_growth(vector infections, int seeding_time) {
   int t = num_elements(infections);
   int ot = t - seeding_time;
   vector[t] log_inf = log(infections); 
-  vector[ot] growth = log_inf[(seeding_time + 1):t] - log_inf[seeding_time:(t -1)];
+  vector[ot] growth = log_inf[(seeding_time + 1):t] - log_inf[seeding_time:(t - 1)];
   return(to_array_1d(growth));
 }

--- a/inst/stan/functions/generated_quantities.stan
+++ b/inst/stan/functions/generated_quantities.stan
@@ -44,3 +44,11 @@ real[] R_to_growth(vector R, real gt_mean, real gt_sd) {
   }
   return(r);
 }
+// Calculate growth rate
+real[] calculate_growth(vector infections, int seeding_time) {
+  int t = num_elements(infections);
+  int ot = t - seeding_time;
+  vector[t] log_inf = log(infections); 
+  vector[ot] growth = log_inf[(seeding_time + 1):t] - log_inf[seeding_time:(t -1)];
+  return(to_array_1d(growth));
+}

--- a/inst/stan/simulate_infections.stan
+++ b/inst/stan/simulate_infections.stan
@@ -27,7 +27,7 @@ generated quantities {
   matrix[n, t] infections; //latent infections
   matrix[n, t - seeding_time] reports; // observed cases
   int imputed_reports[n, t - seeding_time];
-  real r[n, t - seeding_time];
+  real r[n, t - seeding_time - 1];
   for (i in 1:n) {
     // generate infections from Rt trace
     infections[i] = to_row_vector(generate_infections(to_vector(R[i]), seeding_time,
@@ -48,6 +48,6 @@ generated quantities {
     }
    // simulate reported cases
    imputed_reports[i] = report_rng(to_vector(reports[i]), rep_phi[i], model_type);
-   r[i] = calculate_growth(to_vector(infections[i]), seeding_time);
+   r[i] = calculate_growth(to_vector(infections[i]), seeding_time + 1);
   }
 }

--- a/inst/stan/simulate_infections.stan
+++ b/inst/stan/simulate_infections.stan
@@ -48,6 +48,6 @@ generated quantities {
     }
    // simulate reported cases
    imputed_reports[i] = report_rng(to_vector(reports[i]), rep_phi[i], model_type);
-   r[i] = R_to_growth(to_vector(R[i]), gt_mean[i, 1], gt_sd[i, 1]);
+   r[i] = calculate_growth(to_vector(infections[i]), seeding_time);
   }
 }

--- a/src/stanExports_estimate_infections.h
+++ b/src/stanExports_estimate_infections.h
@@ -59,37 +59,37 @@ stan::io::program_reader prog_reader__() {
     reader.add_event(460, 7, "restart", "model_estimate_infections");
     reader.add_event(460, 7, "include", "functions/generated_quantities.stan");
     reader.add_event(460, 0, "start", "functions/generated_quantities.stan");
-    reader.add_event(506, 46, "end", "functions/generated_quantities.stan");
-    reader.add_event(506, 8, "restart", "model_estimate_infections");
-    reader.add_event(510, 12, "include", "data/observations.stan");
-    reader.add_event(510, 0, "start", "data/observations.stan");
-    reader.add_event(516, 6, "end", "data/observations.stan");
-    reader.add_event(516, 13, "restart", "model_estimate_infections");
-    reader.add_event(516, 13, "include", "data/delays.stan");
-    reader.add_event(516, 0, "start", "data/delays.stan");
-    reader.add_event(522, 6, "end", "data/delays.stan");
-    reader.add_event(522, 14, "restart", "model_estimate_infections");
-    reader.add_event(522, 14, "include", "data/gaussian_process.stan");
-    reader.add_event(522, 0, "start", "data/gaussian_process.stan");
-    reader.add_event(532, 10, "end", "data/gaussian_process.stan");
-    reader.add_event(532, 15, "restart", "model_estimate_infections");
-    reader.add_event(532, 15, "include", "data/generation_time.stan");
-    reader.add_event(532, 0, "start", "data/generation_time.stan");
-    reader.add_event(537, 5, "end", "data/generation_time.stan");
-    reader.add_event(537, 16, "restart", "model_estimate_infections");
-    reader.add_event(537, 16, "include", "data/rt.stan");
-    reader.add_event(537, 0, "start", "data/rt.stan");
-    reader.add_event(547, 10, "end", "data/rt.stan");
-    reader.add_event(547, 17, "restart", "model_estimate_infections");
-    reader.add_event(547, 17, "include", "data/backcalc.stan");
-    reader.add_event(547, 0, "start", "data/backcalc.stan");
-    reader.add_event(549, 2, "end", "data/backcalc.stan");
-    reader.add_event(549, 18, "restart", "model_estimate_infections");
-    reader.add_event(549, 18, "include", "data/observation_model.stan");
-    reader.add_event(549, 0, "start", "data/observation_model.stan");
-    reader.add_event(562, 13, "end", "data/observation_model.stan");
-    reader.add_event(562, 19, "restart", "model_estimate_infections");
-    reader.add_event(685, 140, "end", "model_estimate_infections");
+    reader.add_event(514, 54, "end", "functions/generated_quantities.stan");
+    reader.add_event(514, 8, "restart", "model_estimate_infections");
+    reader.add_event(518, 12, "include", "data/observations.stan");
+    reader.add_event(518, 0, "start", "data/observations.stan");
+    reader.add_event(524, 6, "end", "data/observations.stan");
+    reader.add_event(524, 13, "restart", "model_estimate_infections");
+    reader.add_event(524, 13, "include", "data/delays.stan");
+    reader.add_event(524, 0, "start", "data/delays.stan");
+    reader.add_event(530, 6, "end", "data/delays.stan");
+    reader.add_event(530, 14, "restart", "model_estimate_infections");
+    reader.add_event(530, 14, "include", "data/gaussian_process.stan");
+    reader.add_event(530, 0, "start", "data/gaussian_process.stan");
+    reader.add_event(540, 10, "end", "data/gaussian_process.stan");
+    reader.add_event(540, 15, "restart", "model_estimate_infections");
+    reader.add_event(540, 15, "include", "data/generation_time.stan");
+    reader.add_event(540, 0, "start", "data/generation_time.stan");
+    reader.add_event(545, 5, "end", "data/generation_time.stan");
+    reader.add_event(545, 16, "restart", "model_estimate_infections");
+    reader.add_event(545, 16, "include", "data/rt.stan");
+    reader.add_event(545, 0, "start", "data/rt.stan");
+    reader.add_event(555, 10, "end", "data/rt.stan");
+    reader.add_event(555, 17, "restart", "model_estimate_infections");
+    reader.add_event(555, 17, "include", "data/backcalc.stan");
+    reader.add_event(555, 0, "start", "data/backcalc.stan");
+    reader.add_event(557, 2, "end", "data/backcalc.stan");
+    reader.add_event(557, 18, "restart", "model_estimate_infections");
+    reader.add_event(557, 18, "include", "data/observation_model.stan");
+    reader.add_event(557, 0, "start", "data/observation_model.stan");
+    reader.add_event(570, 13, "end", "data/observation_model.stan");
+    reader.add_event(570, 19, "restart", "model_estimate_infections");
+    reader.add_event(690, 137, "end", "model_estimate_infections");
     return reader;
 }
 template <typename T1__, typename T2__>
@@ -171,9 +171,9 @@ discretised_gamma_pmf(const std::vector<int>& y,
         current_statement_begin__ = 21;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 22;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 25;
@@ -277,9 +277,9 @@ discretised_lognormal_pmf(const std::vector<int>& y,
         current_statement_begin__ = 41;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 42;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 45;
@@ -322,9 +322,9 @@ reverse_mf(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& pmf,
         current_statement_begin__ = 51;
         for (int d = 1; d <= max_pmf; ++d) {
             current_statement_begin__ = 52;
-            stan::model::assign(rev_pmf,
-                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()),
-                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1),
+            stan::model::assign(rev_pmf, 
+                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()), 
+                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1), 
                         "assigning variable rev_pmf");
         }
         current_statement_begin__ = 54;
@@ -376,9 +376,9 @@ convolve(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& cases,
         current_statement_begin__ = 61;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 62;
-            stan::model::assign(conv_cases,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))),
+            stan::model::assign(conv_cases, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))), 
                         "assigning variable conv_cases");
         }
         current_statement_begin__ = 65;
@@ -453,9 +453,9 @@ convolve_to_report(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 current_statement_begin__ = 83;
                 for (int i = 1; i <= get_base1(max_delay, s, "max_delay", 1); ++i) {
                     current_statement_begin__ = 84;
-                    stan::model::assign(delay_indexes,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(max_delay, s, "max_delay", 1) - i),
+                    stan::model::assign(delay_indexes, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(max_delay, s, "max_delay", 1) - i), 
                                 "assigning variable delay_indexes");
                 }
                 current_statement_begin__ = 86;
@@ -779,17 +779,17 @@ setup_gp(const int& M,
         current_statement_begin__ = 145;
         for (int s = 1; s <= dimension; ++s) {
             current_statement_begin__ = 146;
-            stan::model::assign(time,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        ((s - half_dim) / half_dim),
+            stan::model::assign(time, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        ((s - half_dim) / half_dim), 
                         "assigning variable time");
         }
         current_statement_begin__ = 148;
         for (int m = 1; m <= M; ++m) {
             current_statement_begin__ = 149;
-            stan::model::assign(PHI,
-                        stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list())),
-                        phi(L, m, time, pstream__),
+            stan::model::assign(PHI, 
+                        stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list())), 
+                        phi(L, m, time, pstream__), 
                         "assigning variable PHI");
         }
         current_statement_begin__ = 151;
@@ -860,18 +860,18 @@ update_gp(const Eigen::Matrix<T0__, Eigen::Dynamic, Eigen::Dynamic>& PHI,
             current_statement_begin__ = 163;
             for (int m = 1; m <= M; ++m) {
                 current_statement_begin__ = 164;
-                stan::model::assign(diagSPD,
-                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()),
-                            stan::math::sqrt(spd_se(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)),
+                stan::model::assign(diagSPD, 
+                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()), 
+                            stan::math::sqrt(spd_se(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)), 
                             "assigning variable diagSPD");
             }
         } else if (as_bool(logical_eq(type, 1))) {
             current_statement_begin__ = 167;
             for (int m = 1; m <= M; ++m) {
                 current_statement_begin__ = 168;
-                stan::model::assign(diagSPD,
-                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()),
-                            stan::math::sqrt(spd_matern(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)),
+                stan::model::assign(diagSPD, 
+                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()), 
+                            stan::math::sqrt(spd_matern(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)), 
                             "assigning variable diagSPD");
             }
         }
@@ -1011,9 +1011,9 @@ update_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& input_R,
                     current_statement_begin__ = 199;
                     stan::math::assign(bp_c, (bp_c + get_base1(bps, s, "bps", 1)));
                     current_statement_begin__ = 200;
-                    stan::model::assign(bp,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                get_base1(bp_effects, bp_c, "bp_effects", 1),
+                    stan::model::assign(bp, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                get_base1(bp_effects, bp_c, "bp_effects", 1), 
                                 "assigning variable bp");
                 }
             }
@@ -1025,23 +1025,23 @@ update_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& input_R,
             current_statement_begin__ = 207;
             if (as_bool(stationary)) {
                 current_statement_begin__ = 208;
-                stan::model::assign(gp,
-                            stan::model::cons_list(stan::model::index_min_max(1, gp_n), stan::model::nil_index_list()),
-                            noise,
+                stan::model::assign(gp, 
+                            stan::model::cons_list(stan::model::index_min_max(1, gp_n), stan::model::nil_index_list()), 
+                            noise, 
                             "assigning variable gp");
                 current_statement_begin__ = 210;
                 if (as_bool(logical_gt(t, gp_n))) {
                     current_statement_begin__ = 211;
-                    stan::model::assign(gp,
-                                stan::model::cons_list(stan::model::index_min_max((gp_n + 1), t), stan::model::nil_index_list()),
-                                rep_vector(get_base1(noise, gp_n, "noise", 1), (t - gp_n)),
+                    stan::model::assign(gp, 
+                                stan::model::cons_list(stan::model::index_min_max((gp_n + 1), t), stan::model::nil_index_list()), 
+                                rep_vector(get_base1(noise, gp_n, "noise", 1), (t - gp_n)), 
                                 "assigning variable gp");
                 }
             } else {
                 current_statement_begin__ = 214;
-                stan::model::assign(gp,
-                            stan::model::cons_list(stan::model::index_min_max(2, (gp_n + 1)), stan::model::nil_index_list()),
-                            noise,
+                stan::model::assign(gp, 
+                            stan::model::cons_list(stan::model::index_min_max(2, (gp_n + 1)), stan::model::nil_index_list()), 
+                            noise, 
                             "assigning variable gp");
                 current_statement_begin__ = 215;
                 stan::math::assign(gp, cumulative_sum(gp));
@@ -1268,43 +1268,43 @@ generate_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& oR,
         current_statement_begin__ = 268;
         for (int i = 1; i <= max_gt; ++i) {
             current_statement_begin__ = 269;
-            stan::model::assign(gt_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((max_gt - i) + 1),
+            stan::model::assign(gt_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((max_gt - i) + 1), 
                         "assigning variable gt_indexes");
         }
         current_statement_begin__ = 271;
         stan::math::assign(gt_pmf, add(gt_pmf, discretised_gamma_pmf(gt_indexes, get_base1(gt_mean, 1, "gt_mean", 1), get_base1(gt_sd, 1, "gt_sd", 1), max_gt, pstream__)));
         current_statement_begin__ = 273;
-        stan::model::assign(infections,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    stan::math::exp(get_base1(initial_infections, 1, "initial_infections", 1)),
+        stan::model::assign(infections, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    stan::math::exp(get_base1(initial_infections, 1, "initial_infections", 1)), 
                     "assigning variable infections");
         current_statement_begin__ = 274;
         if (as_bool(logical_gt(uot, 1))) {
             current_statement_begin__ = 275;
             for (int s = 2; s <= uot; ++s) {
                 current_statement_begin__ = 276;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            stan::math::exp((get_base1(initial_infections, 1, "initial_infections", 1) + (get_base1(initial_growth, 1, "initial_growth", 1) * (s - 1)))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            stan::math::exp((get_base1(initial_infections, 1, "initial_infections", 1) + (get_base1(initial_growth, 1, "initial_growth", 1) * (s - 1)))), 
                             "assigning variable infections");
             }
         }
         current_statement_begin__ = 280;
         if (as_bool(pop)) {
             current_statement_begin__ = 281;
-            stan::model::assign(cum_infections,
-                        stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                        sum(stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_min_max(1, uot), stan::model::nil_index_list()), "infections")),
+            stan::model::assign(cum_infections, 
+                        stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                        sum(stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_min_max(1, uot), stan::model::nil_index_list()), "infections")), 
                         "assigning variable cum_infections");
         }
         current_statement_begin__ = 284;
         for (int s = 1; s <= ot; ++s) {
             current_statement_begin__ = 285;
-            stan::model::assign(infectiousness,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, uot, max_gt, s, pstream__)),
+            stan::model::assign(infectiousness, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, uot, max_gt, s, pstream__)), 
                         "assigning variable infectiousness");
             current_statement_begin__ = 286;
             if (as_bool((primitive_value(pop) && primitive_value(logical_gt(s, nht))))) {
@@ -1313,23 +1313,23 @@ generate_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& oR,
                 current_statement_begin__ = 288;
                 stan::math::assign(exp_adj_Rt, (logical_gt(exp_adj_Rt, 1) ? stan::math::promote_scalar<local_scalar_t__>(1) : stan::math::promote_scalar<local_scalar_t__>(exp_adj_Rt) ));
                 current_statement_begin__ = 289;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()),
-                            ((pop - get_base1(cum_infections, s, "cum_infections", 1)) * (1 - exp_adj_Rt)),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), 
+                            ((pop - get_base1(cum_infections, s, "cum_infections", 1)) * (1 - exp_adj_Rt)), 
                             "assigning variable infections");
             } else {
                 current_statement_begin__ = 291;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()),
-                            (stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), "infections") + (get_base1(R, s, "R", 1) * get_base1(infectiousness, s, "infectiousness", 1))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), 
+                            (stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), "infections") + (get_base1(R, s, "R", 1) * get_base1(infectiousness, s, "infectiousness", 1))), 
                             "assigning variable infections");
             }
             current_statement_begin__ = 293;
             if (as_bool((primitive_value(pop) && primitive_value(logical_lt(s, ot))))) {
                 current_statement_begin__ = 294;
-                stan::model::assign(cum_infections,
-                            stan::model::cons_list(stan::model::index_uni((s + 1)), stan::model::nil_index_list()),
-                            (get_base1(cum_infections, s, "cum_infections", 1) + get_base1(infections, (s + uot), "infections", 1)),
+                stan::model::assign(cum_infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + 1)), stan::model::nil_index_list()), 
+                            (get_base1(cum_infections, s, "cum_infections", 1) + get_base1(infections, (s + uot), "infections", 1)), 
                             "assigning variable cum_infections");
             }
         }
@@ -1401,16 +1401,16 @@ deconvolve_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& shifted_case
                 stan::math::assign(infections, add(infections, exp_noise));
             } else if (as_bool(logical_eq(prior, 2))) {
                 current_statement_begin__ = 311;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                            (get_base1(infections, 1, "infections", 1) + (get_base1(shifted_cases, 1, "shifted_cases", 1) * get_base1(exp_noise, 1, "exp_noise", 1))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                            (get_base1(infections, 1, "infections", 1) + (get_base1(shifted_cases, 1, "shifted_cases", 1) * get_base1(exp_noise, 1, "exp_noise", 1))), 
                             "assigning variable infections");
                 current_statement_begin__ = 312;
                 for (int i = 2; i <= t; ++i) {
                     current_statement_begin__ = 313;
-                    stan::model::assign(infections,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(infections, (i - 1), "infections", 1) * get_base1(exp_noise, i, "exp_noise", 1)),
+                    stan::model::assign(infections, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(infections, (i - 1), "infections", 1) * get_base1(exp_noise, i, "exp_noise", 1)), 
                                 "assigning variable infections");
                 }
             }
@@ -1511,9 +1511,9 @@ day_of_week_effect(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
         current_statement_begin__ = 334;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 336;
-            stan::model::assign(scaled_reports,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)),
+            stan::model::assign(scaled_reports, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)), 
                         "assigning variable scaled_reports");
         }
         current_statement_begin__ = 338;
@@ -1602,17 +1602,17 @@ truncation_cmf(const T0__& trunc_mean,
         current_statement_begin__ = 352;
         for (int i = 1; i <= trunc_max; ++i) {
             current_statement_begin__ = 353;
-            stan::model::assign(trunc_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (i - 1),
+            stan::model::assign(trunc_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (i - 1), 
                         "assigning variable trunc_indexes");
         }
         current_statement_begin__ = 355;
         stan::math::assign(cmf, discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max, pstream__));
         current_statement_begin__ = 356;
-        stan::model::assign(cmf,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (get_base1(cmf, 1, "cmf", 1) + 1e-8),
+        stan::model::assign(cmf, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (get_base1(cmf, 1, "cmf", 1) + 1e-8), 
                     "assigning variable cmf");
         current_statement_begin__ = 357;
         stan::math::assign(cmf, cumulative_sum(cmf));
@@ -1695,15 +1695,15 @@ truncate(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 375;
             if (as_bool(reconstruct)) {
                 current_statement_begin__ = 376;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             } else {
                 current_statement_begin__ = 378;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             }
             }
@@ -1877,18 +1877,18 @@ report_log_lik(const std::vector<int>& cases,
                 current_statement_begin__ = 422;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 423;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                                 "assigning variable log_lik");
                 }
             } else {
                 current_statement_begin__ = 426;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 427;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight), 
                                 "assigning variable log_lik");
                 }
             }
@@ -1897,9 +1897,9 @@ report_log_lik(const std::vector<int>& cases,
             current_statement_begin__ = 431;
             for (int i = 1; i <= t; ++i) {
                 current_statement_begin__ = 432;
-                stan::model::assign(log_lik,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                stan::model::assign(log_lik, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                             "assigning variable log_lik");
             }
         }
@@ -1960,15 +1960,15 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 446;
                 if (as_bool(logical_gt(sqrt_phi, 1e4))) {
                     current_statement_begin__ = 447;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                                 "assigning variable sampled_reports");
                 } else {
                     current_statement_begin__ = 449;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__), 
                                 "assigning variable sampled_reports");
                 }
             }
@@ -1976,9 +1976,9 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 453;
             for (int s = 1; s <= t; ++s) {
                 current_statement_begin__ = 454;
-                stan::model::assign(sampled_reports,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                stan::model::assign(sampled_reports, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                             "assigning variable sampled_reports");
             }
         }
@@ -2055,9 +2055,9 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
         current_statement_begin__ = 473;
         for (int i = 1; i <= max_gt; ++i) {
             current_statement_begin__ = 474;
-            stan::model::assign(gt_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((max_gt - i) + 1),
+            stan::model::assign(gt_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((max_gt - i) + 1), 
                         "assigning variable gt_indexes");
         }
         current_statement_begin__ = 476;
@@ -2065,14 +2065,14 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
         current_statement_begin__ = 478;
         for (int s = 1; s <= ot; ++s) {
             current_statement_begin__ = 479;
-            stan::model::assign(infectiousness,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, seeding_time, max_gt, s, pstream__)),
+            stan::model::assign(infectiousness, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, seeding_time, max_gt, s, pstream__)), 
                         "assigning variable infectiousness");
             current_statement_begin__ = 480;
-            stan::model::assign(R,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(infections, (s + seeding_time), "infections", 1) / get_base1(infectiousness, s, "infectiousness", 1)),
+            stan::model::assign(R, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(infections, (s + seeding_time), "infections", 1) / get_base1(infectiousness, s, "infectiousness", 1)), 
                         "assigning variable R");
         }
         current_statement_begin__ = 482;
@@ -2087,24 +2087,24 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 stan::math::fill(window, DUMMY_VAR__);
                 stan::math::assign(window,0);
                 current_statement_begin__ = 485;
-                stan::model::assign(sR,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            0,
+                stan::model::assign(sR, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            0, 
                             "assigning variable sR");
                 current_statement_begin__ = 486;
                 for (int i = std::max(1, (s - smooth)); i <= std::min(ot, (s + smooth)); ++i) {
                     current_statement_begin__ = 487;
-                    stan::model::assign(sR,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                (stan::model::rvalue(sR, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "sR") + get_base1(R, i, "R", 1)),
+                    stan::model::assign(sR, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(sR, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "sR") + get_base1(R, i, "R", 1)), 
                                 "assigning variable sR");
                     current_statement_begin__ = 488;
                     stan::math::assign(window, (window + 1));
                 }
                 current_statement_begin__ = 490;
-                stan::model::assign(sR,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            (get_base1(sR, s, "sR", 1) / window),
+                stan::model::assign(sR, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            (get_base1(sR, s, "sR", 1) / window), 
                             "assigning variable sR");
                 }
             }
@@ -2166,9 +2166,9 @@ R_to_growth(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& R,
         current_statement_begin__ = 502;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 503;
-            stan::model::assign(r,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        ((pow(get_base1(R, s, "R", 1), k) - 1) / (k * gt_mean)),
+            stan::model::assign(r, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        ((pow(get_base1(R, s, "R", 1), k) - 1) / (k * gt_mean)), 
                         "assigning variable r");
         }
         current_statement_begin__ = 505;
@@ -2187,6 +2187,58 @@ struct R_to_growth_functor__ {
                 const T1__& gt_mean,
                 const T2__& gt_sd, std::ostream* pstream__) const {
         return R_to_growth(R, gt_mean, gt_sd, pstream__);
+    }
+};
+template <typename T0__>
+std::vector<typename boost::math::tools::promote_args<T0__>::type>
+calculate_growth(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
+                     const int& seeding_time, std::ostream* pstream__) {
+    typedef typename boost::math::tools::promote_args<T0__>::type local_scalar_t__;
+    typedef local_scalar_t__ fun_return_scalar_t__;
+    const static bool propto__ = true;
+    (void) propto__;
+        local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+        (void) DUMMY_VAR__;  // suppress unused var warning
+    int current_statement_begin__ = -1;
+    try {
+        {
+        current_statement_begin__ = 509;
+        int t(0);
+        (void) t;  // dummy to suppress unused var warning
+        stan::math::fill(t, std::numeric_limits<int>::min());
+        stan::math::assign(t,num_elements(infections));
+        current_statement_begin__ = 510;
+        int ot(0);
+        (void) ot;  // dummy to suppress unused var warning
+        stan::math::fill(ot, std::numeric_limits<int>::min());
+        stan::math::assign(ot,(t - seeding_time));
+        current_statement_begin__ = 511;
+        validate_non_negative_index("log_inf", "t", t);
+        Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> log_inf(t);
+        stan::math::initialize(log_inf, DUMMY_VAR__);
+        stan::math::fill(log_inf, DUMMY_VAR__);
+        stan::math::assign(log_inf,stan::math::log(infections));
+        current_statement_begin__ = 512;
+        validate_non_negative_index("growth", "ot", ot);
+        Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> growth(ot);
+        stan::math::initialize(growth, DUMMY_VAR__);
+        stan::math::fill(growth, DUMMY_VAR__);
+        stan::math::assign(growth,subtract(stan::model::rvalue(log_inf, stan::model::cons_list(stan::model::index_min_max((seeding_time + 1), t), stan::model::nil_index_list()), "log_inf"), stan::model::rvalue(log_inf, stan::model::cons_list(stan::model::index_min_max(seeding_time, (t - 1)), stan::model::nil_index_list()), "log_inf")));
+        current_statement_begin__ = 513;
+        return stan::math::promote_scalar<fun_return_scalar_t__>(to_array_1d(growth));
+        }
+    } catch (const std::exception& e) {
+        stan::lang::rethrow_located(e, current_statement_begin__, prog_reader__());
+        // Next line prevents compiler griping about no return
+        throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***");
+    }
+}
+struct calculate_growth_functor__ {
+    template <typename T0__>
+        std::vector<typename boost::math::tools::promote_args<T0__>::type>
+    operator()(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
+                     const int& seeding_time, std::ostream* pstream__) const {
+        return calculate_growth(infections, seeding_time, pstream__);
     }
 };
 #include <stan_meta_header.hpp>
@@ -2281,31 +2333,31 @@ public:
         (void) DUMMY_VAR__;  // suppress unused var warning
         try {
             // initialize data block variables from context__
-            current_statement_begin__ = 511;
+            current_statement_begin__ = 519;
             context__.validate_dims("data initialization", "t", "int", context__.to_vec());
             t = int(0);
             vals_i__ = context__.vals_i("t");
             pos__ = 0;
             t = vals_i__[pos__++];
-            current_statement_begin__ = 512;
+            current_statement_begin__ = 520;
             context__.validate_dims("data initialization", "seeding_time", "int", context__.to_vec());
             seeding_time = int(0);
             vals_i__ = context__.vals_i("seeding_time");
             pos__ = 0;
             seeding_time = vals_i__[pos__++];
-            current_statement_begin__ = 513;
+            current_statement_begin__ = 521;
             context__.validate_dims("data initialization", "horizon", "int", context__.to_vec());
             horizon = int(0);
             vals_i__ = context__.vals_i("horizon");
             pos__ = 0;
             horizon = vals_i__[pos__++];
-            current_statement_begin__ = 514;
+            current_statement_begin__ = 522;
             context__.validate_dims("data initialization", "future_time", "int", context__.to_vec());
             future_time = int(0);
             vals_i__ = context__.vals_i("future_time");
             pos__ = 0;
             future_time = vals_i__[pos__++];
-            current_statement_begin__ = 515;
+            current_statement_begin__ = 523;
             validate_non_negative_index("cases", "((t - horizon) - seeding_time)", ((t - horizon) - seeding_time));
             context__.validate_dims("data initialization", "cases", "int", context__.to_vec(((t - horizon) - seeding_time)));
             cases = std::vector<int>(((t - horizon) - seeding_time), int(0));
@@ -2319,7 +2371,7 @@ public:
             for (size_t i_0__ = 0; i_0__ < cases_i_0_max__; ++i_0__) {
                 check_greater_or_equal(function__, "cases[i_0__]", cases[i_0__], 0);
             }
-            current_statement_begin__ = 516;
+            current_statement_begin__ = 524;
             validate_non_negative_index("shifted_cases", "t", t);
             context__.validate_dims("data initialization", "shifted_cases", "vector_d", context__.to_vec(t));
             shifted_cases = Eigen::Matrix<double, Eigen::Dynamic, 1>(t);
@@ -2330,13 +2382,13 @@ public:
                 shifted_cases(j_1__) = vals_r__[pos__++];
             }
             check_greater_or_equal(function__, "shifted_cases", shifted_cases, 0);
-            current_statement_begin__ = 517;
+            current_statement_begin__ = 525;
             context__.validate_dims("data initialization", "delays", "int", context__.to_vec());
             delays = int(0);
             vals_i__ = context__.vals_i("delays");
             pos__ = 0;
             delays = vals_i__[pos__++];
-            current_statement_begin__ = 518;
+            current_statement_begin__ = 526;
             validate_non_negative_index("delay_mean_sd", "delays", delays);
             context__.validate_dims("data initialization", "delay_mean_sd", "double", context__.to_vec(delays));
             delay_mean_sd = std::vector<double>(delays, double(0));
@@ -2346,7 +2398,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < delay_mean_sd_k_0_max__; ++k_0__) {
                 delay_mean_sd[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 519;
+            current_statement_begin__ = 527;
             validate_non_negative_index("delay_mean_mean", "delays", delays);
             context__.validate_dims("data initialization", "delay_mean_mean", "double", context__.to_vec(delays));
             delay_mean_mean = std::vector<double>(delays, double(0));
@@ -2356,7 +2408,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < delay_mean_mean_k_0_max__; ++k_0__) {
                 delay_mean_mean[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 520;
+            current_statement_begin__ = 528;
             validate_non_negative_index("delay_sd_mean", "delays", delays);
             context__.validate_dims("data initialization", "delay_sd_mean", "double", context__.to_vec(delays));
             delay_sd_mean = std::vector<double>(delays, double(0));
@@ -2366,7 +2418,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < delay_sd_mean_k_0_max__; ++k_0__) {
                 delay_sd_mean[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 521;
+            current_statement_begin__ = 529;
             validate_non_negative_index("delay_sd_sd", "delays", delays);
             context__.validate_dims("data initialization", "delay_sd_sd", "double", context__.to_vec(delays));
             delay_sd_sd = std::vector<double>(delays, double(0));
@@ -2376,7 +2428,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < delay_sd_sd_k_0_max__; ++k_0__) {
                 delay_sd_sd[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 522;
+            current_statement_begin__ = 530;
             validate_non_negative_index("max_delay", "delays", delays);
             context__.validate_dims("data initialization", "max_delay", "int", context__.to_vec(delays));
             max_delay = std::vector<int>(delays, int(0));
@@ -2386,138 +2438,138 @@ public:
             for (size_t k_0__ = 0; k_0__ < max_delay_k_0_max__; ++k_0__) {
                 max_delay[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 523;
+            current_statement_begin__ = 531;
             context__.validate_dims("data initialization", "L", "double", context__.to_vec());
             L = double(0);
             vals_r__ = context__.vals_r("L");
             pos__ = 0;
             L = vals_r__[pos__++];
-            current_statement_begin__ = 524;
+            current_statement_begin__ = 532;
             context__.validate_dims("data initialization", "M", "int", context__.to_vec());
             M = int(0);
             vals_i__ = context__.vals_i("M");
             pos__ = 0;
             M = vals_i__[pos__++];
             check_greater_or_equal(function__, "M", M, 1);
-            current_statement_begin__ = 525;
+            current_statement_begin__ = 533;
             context__.validate_dims("data initialization", "ls_meanlog", "double", context__.to_vec());
             ls_meanlog = double(0);
             vals_r__ = context__.vals_r("ls_meanlog");
             pos__ = 0;
             ls_meanlog = vals_r__[pos__++];
-            current_statement_begin__ = 526;
+            current_statement_begin__ = 534;
             context__.validate_dims("data initialization", "ls_sdlog", "double", context__.to_vec());
             ls_sdlog = double(0);
             vals_r__ = context__.vals_r("ls_sdlog");
             pos__ = 0;
             ls_sdlog = vals_r__[pos__++];
-            current_statement_begin__ = 527;
+            current_statement_begin__ = 535;
             context__.validate_dims("data initialization", "ls_min", "double", context__.to_vec());
             ls_min = double(0);
             vals_r__ = context__.vals_r("ls_min");
             pos__ = 0;
             ls_min = vals_r__[pos__++];
             check_greater_or_equal(function__, "ls_min", ls_min, 0);
-            current_statement_begin__ = 528;
+            current_statement_begin__ = 536;
             context__.validate_dims("data initialization", "ls_max", "double", context__.to_vec());
             ls_max = double(0);
             vals_r__ = context__.vals_r("ls_max");
             pos__ = 0;
             ls_max = vals_r__[pos__++];
             check_greater_or_equal(function__, "ls_max", ls_max, 0);
-            current_statement_begin__ = 529;
+            current_statement_begin__ = 537;
             context__.validate_dims("data initialization", "alpha_sd", "double", context__.to_vec());
             alpha_sd = double(0);
             vals_r__ = context__.vals_r("alpha_sd");
             pos__ = 0;
             alpha_sd = vals_r__[pos__++];
-            current_statement_begin__ = 530;
+            current_statement_begin__ = 538;
             context__.validate_dims("data initialization", "gp_type", "int", context__.to_vec());
             gp_type = int(0);
             vals_i__ = context__.vals_i("gp_type");
             pos__ = 0;
             gp_type = vals_i__[pos__++];
-            current_statement_begin__ = 531;
+            current_statement_begin__ = 539;
             context__.validate_dims("data initialization", "stationary", "int", context__.to_vec());
             stationary = int(0);
             vals_i__ = context__.vals_i("stationary");
             pos__ = 0;
             stationary = vals_i__[pos__++];
-            current_statement_begin__ = 532;
+            current_statement_begin__ = 540;
             context__.validate_dims("data initialization", "fixed", "int", context__.to_vec());
             fixed = int(0);
             vals_i__ = context__.vals_i("fixed");
             pos__ = 0;
             fixed = vals_i__[pos__++];
-            current_statement_begin__ = 533;
+            current_statement_begin__ = 541;
             context__.validate_dims("data initialization", "gt_mean_sd", "double", context__.to_vec());
             gt_mean_sd = double(0);
             vals_r__ = context__.vals_r("gt_mean_sd");
             pos__ = 0;
             gt_mean_sd = vals_r__[pos__++];
-            current_statement_begin__ = 534;
+            current_statement_begin__ = 542;
             context__.validate_dims("data initialization", "gt_mean_mean", "double", context__.to_vec());
             gt_mean_mean = double(0);
             vals_r__ = context__.vals_r("gt_mean_mean");
             pos__ = 0;
             gt_mean_mean = vals_r__[pos__++];
-            current_statement_begin__ = 535;
+            current_statement_begin__ = 543;
             context__.validate_dims("data initialization", "gt_sd_mean", "double", context__.to_vec());
             gt_sd_mean = double(0);
             vals_r__ = context__.vals_r("gt_sd_mean");
             pos__ = 0;
             gt_sd_mean = vals_r__[pos__++];
-            current_statement_begin__ = 536;
+            current_statement_begin__ = 544;
             context__.validate_dims("data initialization", "gt_sd_sd", "double", context__.to_vec());
             gt_sd_sd = double(0);
             vals_r__ = context__.vals_r("gt_sd_sd");
             pos__ = 0;
             gt_sd_sd = vals_r__[pos__++];
-            current_statement_begin__ = 537;
+            current_statement_begin__ = 545;
             context__.validate_dims("data initialization", "max_gt", "int", context__.to_vec());
             max_gt = int(0);
             vals_i__ = context__.vals_i("max_gt");
             pos__ = 0;
             max_gt = vals_i__[pos__++];
-            current_statement_begin__ = 538;
+            current_statement_begin__ = 546;
             context__.validate_dims("data initialization", "estimate_r", "int", context__.to_vec());
             estimate_r = int(0);
             vals_i__ = context__.vals_i("estimate_r");
             pos__ = 0;
             estimate_r = vals_i__[pos__++];
-            current_statement_begin__ = 539;
+            current_statement_begin__ = 547;
             context__.validate_dims("data initialization", "prior_infections", "double", context__.to_vec());
             prior_infections = double(0);
             vals_r__ = context__.vals_r("prior_infections");
             pos__ = 0;
             prior_infections = vals_r__[pos__++];
-            current_statement_begin__ = 540;
+            current_statement_begin__ = 548;
             context__.validate_dims("data initialization", "prior_growth", "double", context__.to_vec());
             prior_growth = double(0);
             vals_r__ = context__.vals_r("prior_growth");
             pos__ = 0;
             prior_growth = vals_r__[pos__++];
-            current_statement_begin__ = 541;
+            current_statement_begin__ = 549;
             context__.validate_dims("data initialization", "r_mean", "double", context__.to_vec());
             r_mean = double(0);
             vals_r__ = context__.vals_r("r_mean");
             pos__ = 0;
             r_mean = vals_r__[pos__++];
             check_greater_or_equal(function__, "r_mean", r_mean, 0);
-            current_statement_begin__ = 542;
+            current_statement_begin__ = 550;
             context__.validate_dims("data initialization", "r_sd", "double", context__.to_vec());
             r_sd = double(0);
             vals_r__ = context__.vals_r("r_sd");
             pos__ = 0;
             r_sd = vals_r__[pos__++];
             check_greater_or_equal(function__, "r_sd", r_sd, 0);
-            current_statement_begin__ = 543;
+            current_statement_begin__ = 551;
             context__.validate_dims("data initialization", "bp_n", "int", context__.to_vec());
             bp_n = int(0);
             vals_i__ = context__.vals_i("bp_n");
             pos__ = 0;
             bp_n = vals_i__[pos__++];
-            current_statement_begin__ = 544;
+            current_statement_begin__ = 552;
             validate_non_negative_index("breakpoints", "(t - seeding_time)", (t - seeding_time));
             context__.validate_dims("data initialization", "breakpoints", "int", context__.to_vec((t - seeding_time)));
             breakpoints = std::vector<int>((t - seeding_time), int(0));
@@ -2527,37 +2579,37 @@ public:
             for (size_t k_0__ = 0; k_0__ < breakpoints_k_0_max__; ++k_0__) {
                 breakpoints[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 545;
+            current_statement_begin__ = 553;
             context__.validate_dims("data initialization", "future_fixed", "int", context__.to_vec());
             future_fixed = int(0);
             vals_i__ = context__.vals_i("future_fixed");
             pos__ = 0;
             future_fixed = vals_i__[pos__++];
-            current_statement_begin__ = 546;
+            current_statement_begin__ = 554;
             context__.validate_dims("data initialization", "fixed_from", "int", context__.to_vec());
             fixed_from = int(0);
             vals_i__ = context__.vals_i("fixed_from");
             pos__ = 0;
             fixed_from = vals_i__[pos__++];
-            current_statement_begin__ = 547;
+            current_statement_begin__ = 555;
             context__.validate_dims("data initialization", "pop", "int", context__.to_vec());
             pop = int(0);
             vals_i__ = context__.vals_i("pop");
             pos__ = 0;
             pop = vals_i__[pos__++];
-            current_statement_begin__ = 548;
+            current_statement_begin__ = 556;
             context__.validate_dims("data initialization", "backcalc_prior", "int", context__.to_vec());
             backcalc_prior = int(0);
             vals_i__ = context__.vals_i("backcalc_prior");
             pos__ = 0;
             backcalc_prior = vals_i__[pos__++];
-            current_statement_begin__ = 549;
+            current_statement_begin__ = 557;
             context__.validate_dims("data initialization", "rt_half_window", "int", context__.to_vec());
             rt_half_window = int(0);
             vals_i__ = context__.vals_i("rt_half_window");
             pos__ = 0;
             rt_half_window = vals_i__[pos__++];
-            current_statement_begin__ = 550;
+            current_statement_begin__ = 558;
             validate_non_negative_index("day_of_week", "(t - seeding_time)", (t - seeding_time));
             context__.validate_dims("data initialization", "day_of_week", "int", context__.to_vec((t - seeding_time)));
             day_of_week = std::vector<int>((t - seeding_time), int(0));
@@ -2567,25 +2619,25 @@ public:
             for (size_t k_0__ = 0; k_0__ < day_of_week_k_0_max__; ++k_0__) {
                 day_of_week[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 551;
+            current_statement_begin__ = 559;
             context__.validate_dims("data initialization", "model_type", "int", context__.to_vec());
             model_type = int(0);
             vals_i__ = context__.vals_i("model_type");
             pos__ = 0;
             model_type = vals_i__[pos__++];
-            current_statement_begin__ = 552;
+            current_statement_begin__ = 560;
             context__.validate_dims("data initialization", "week_effect", "int", context__.to_vec());
             week_effect = int(0);
             vals_i__ = context__.vals_i("week_effect");
             pos__ = 0;
             week_effect = vals_i__[pos__++];
-            current_statement_begin__ = 553;
+            current_statement_begin__ = 561;
             context__.validate_dims("data initialization", "truncation", "int", context__.to_vec());
             truncation = int(0);
             vals_i__ = context__.vals_i("truncation");
             pos__ = 0;
             truncation = vals_i__[pos__++];
-            current_statement_begin__ = 554;
+            current_statement_begin__ = 562;
             validate_non_negative_index("trunc_mean_mean", "truncation", truncation);
             context__.validate_dims("data initialization", "trunc_mean_mean", "double", context__.to_vec(truncation));
             trunc_mean_mean = std::vector<double>(truncation, double(0));
@@ -2595,7 +2647,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < trunc_mean_mean_k_0_max__; ++k_0__) {
                 trunc_mean_mean[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 555;
+            current_statement_begin__ = 563;
             validate_non_negative_index("trunc_mean_sd", "truncation", truncation);
             context__.validate_dims("data initialization", "trunc_mean_sd", "double", context__.to_vec(truncation));
             trunc_mean_sd = std::vector<double>(truncation, double(0));
@@ -2605,7 +2657,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < trunc_mean_sd_k_0_max__; ++k_0__) {
                 trunc_mean_sd[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 556;
+            current_statement_begin__ = 564;
             validate_non_negative_index("trunc_sd_mean", "truncation", truncation);
             context__.validate_dims("data initialization", "trunc_sd_mean", "double", context__.to_vec(truncation));
             trunc_sd_mean = std::vector<double>(truncation, double(0));
@@ -2615,7 +2667,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < trunc_sd_mean_k_0_max__; ++k_0__) {
                 trunc_sd_mean[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 557;
+            current_statement_begin__ = 565;
             validate_non_negative_index("trunc_sd_sd", "truncation", truncation);
             context__.validate_dims("data initialization", "trunc_sd_sd", "double", context__.to_vec(truncation));
             trunc_sd_sd = std::vector<double>(truncation, double(0));
@@ -2625,7 +2677,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < trunc_sd_sd_k_0_max__; ++k_0__) {
                 trunc_sd_sd[k_0__] = vals_r__[pos__++];
             }
-            current_statement_begin__ = 558;
+            current_statement_begin__ = 566;
             validate_non_negative_index("max_truncation", "truncation", truncation);
             context__.validate_dims("data initialization", "max_truncation", "int", context__.to_vec(truncation));
             max_truncation = std::vector<int>(truncation, int(0));
@@ -2635,54 +2687,54 @@ public:
             for (size_t k_0__ = 0; k_0__ < max_truncation_k_0_max__; ++k_0__) {
                 max_truncation[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 559;
+            current_statement_begin__ = 567;
             context__.validate_dims("data initialization", "obs_scale", "int", context__.to_vec());
             obs_scale = int(0);
             vals_i__ = context__.vals_i("obs_scale");
             pos__ = 0;
             obs_scale = vals_i__[pos__++];
-            current_statement_begin__ = 560;
+            current_statement_begin__ = 568;
             context__.validate_dims("data initialization", "obs_scale_mean", "double", context__.to_vec());
             obs_scale_mean = double(0);
             vals_r__ = context__.vals_r("obs_scale_mean");
             pos__ = 0;
             obs_scale_mean = vals_r__[pos__++];
-            current_statement_begin__ = 561;
+            current_statement_begin__ = 569;
             context__.validate_dims("data initialization", "obs_scale_sd", "double", context__.to_vec());
             obs_scale_sd = double(0);
             vals_r__ = context__.vals_r("obs_scale_sd");
             pos__ = 0;
             obs_scale_sd = vals_r__[pos__++];
-            current_statement_begin__ = 562;
+            current_statement_begin__ = 570;
             context__.validate_dims("data initialization", "obs_weight", "double", context__.to_vec());
             obs_weight = double(0);
             vals_r__ = context__.vals_r("obs_weight");
             pos__ = 0;
             obs_weight = vals_r__[pos__++];
             // initialize transformed data variables
-            current_statement_begin__ = 567;
+            current_statement_begin__ = 575;
             ot = int(0);
             stan::math::fill(ot, std::numeric_limits<int>::min());
             stan::math::assign(ot,((t - seeding_time) - horizon));
-            current_statement_begin__ = 568;
+            current_statement_begin__ = 576;
             ot_h = int(0);
             stan::math::fill(ot_h, std::numeric_limits<int>::min());
             stan::math::assign(ot_h,(ot + horizon));
-            current_statement_begin__ = 570;
+            current_statement_begin__ = 578;
             noise_terms = int(0);
             stan::math::fill(noise_terms, std::numeric_limits<int>::min());
             stan::math::assign(noise_terms,setup_noise(ot_h, t, horizon, estimate_r, stationary, future_fixed, fixed_from, pstream__));
-            current_statement_begin__ = 571;
+            current_statement_begin__ = 579;
             validate_non_negative_index("PHI", "noise_terms", noise_terms);
             validate_non_negative_index("PHI", "M", M);
             PHI = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic>(noise_terms, M);
             stan::math::fill(PHI, DUMMY_VAR__);
             stan::math::assign(PHI,setup_gp(M, L, noise_terms, pstream__));
-            current_statement_begin__ = 573;
+            current_statement_begin__ = 581;
             r_logmean = double(0);
             stan::math::fill(r_logmean, DUMMY_VAR__);
             stan::math::assign(r_logmean,stan::math::log((pow(r_mean, 2) / stan::math::sqrt((pow(r_sd, 2) + pow(r_mean, 2))))));
-            current_statement_begin__ = 574;
+            current_statement_begin__ = 582;
             r_logsd = double(0);
             stan::math::fill(r_logsd, DUMMY_VAR__);
             stan::math::assign(r_logsd,stan::math::sqrt(stan::math::log((1 + (pow(r_sd, 2) / pow(r_mean, 2))))));
@@ -2691,55 +2743,55 @@ public:
             // validate, set parameter ranges
             num_params_r__ = 0U;
             param_ranges_i__.clear();
-            current_statement_begin__ = 579;
+            current_statement_begin__ = 587;
             validate_non_negative_index("rho", "(fixed ? 0 : 1 )", (fixed ? 0 : 1 ));
             num_params_r__ += (1 * (fixed ? 0 : 1 ));
-            current_statement_begin__ = 580;
+            current_statement_begin__ = 588;
             validate_non_negative_index("alpha", "(fixed ? 0 : 1 )", (fixed ? 0 : 1 ));
             num_params_r__ += (1 * (fixed ? 0 : 1 ));
-            current_statement_begin__ = 581;
+            current_statement_begin__ = 589;
             validate_non_negative_index("eta", "(fixed ? 0 : M )", (fixed ? 0 : M ));
             num_params_r__ += (fixed ? 0 : M );
-            current_statement_begin__ = 583;
+            current_statement_begin__ = 591;
             validate_non_negative_index("log_R", "estimate_r", estimate_r);
             num_params_r__ += estimate_r;
-            current_statement_begin__ = 584;
+            current_statement_begin__ = 592;
             validate_non_negative_index("initial_infections", "estimate_r", estimate_r);
             num_params_r__ += (1 * estimate_r);
-            current_statement_begin__ = 585;
+            current_statement_begin__ = 593;
             validate_non_negative_index("initial_growth", "((primitive_value(estimate_r) && primitive_value(logical_gt(seeding_time, 1))) ? 1 : 0 )", ((primitive_value(estimate_r) && primitive_value(logical_gt(seeding_time, 1))) ? 1 : 0 ));
             num_params_r__ += (1 * ((primitive_value(estimate_r) && primitive_value(logical_gt(seeding_time, 1))) ? 1 : 0 ));
-            current_statement_begin__ = 586;
+            current_statement_begin__ = 594;
             validate_non_negative_index("gt_mean", "estimate_r", estimate_r);
             num_params_r__ += (1 * estimate_r);
-            current_statement_begin__ = 587;
+            current_statement_begin__ = 595;
             validate_non_negative_index("gt_sd", "estimate_r", estimate_r);
             num_params_r__ += (1 * estimate_r);
-            current_statement_begin__ = 588;
+            current_statement_begin__ = 596;
             validate_non_negative_index("bp_sd", "(logical_gt(bp_n, 0) ? 1 : 0 )", (logical_gt(bp_n, 0) ? 1 : 0 ));
             num_params_r__ += (1 * (logical_gt(bp_n, 0) ? 1 : 0 ));
-            current_statement_begin__ = 589;
+            current_statement_begin__ = 597;
             validate_non_negative_index("bp_effects", "bp_n", bp_n);
             num_params_r__ += (1 * bp_n);
-            current_statement_begin__ = 591;
+            current_statement_begin__ = 599;
             validate_non_negative_index("delay_mean", "delays", delays);
             num_params_r__ += (1 * delays);
-            current_statement_begin__ = 592;
+            current_statement_begin__ = 600;
             validate_non_negative_index("delay_sd", "delays", delays);
             num_params_r__ += (1 * delays);
-            current_statement_begin__ = 593;
+            current_statement_begin__ = 601;
             validate_non_negative_index("day_of_week_simplex", "(week_effect ? 7 : 1 )", (week_effect ? 7 : 1 ));
             num_params_r__ += ((week_effect ? 7 : 1 ) - 1);
-            current_statement_begin__ = 594;
+            current_statement_begin__ = 602;
             validate_non_negative_index("frac_obs", "obs_scale", obs_scale);
             num_params_r__ += (1 * obs_scale);
-            current_statement_begin__ = 595;
+            current_statement_begin__ = 603;
             validate_non_negative_index("truncation_mean", "truncation", truncation);
             num_params_r__ += (1 * truncation);
-            current_statement_begin__ = 596;
+            current_statement_begin__ = 604;
             validate_non_negative_index("truncation_sd", "truncation", truncation);
             num_params_r__ += (1 * truncation);
-            current_statement_begin__ = 597;
+            current_statement_begin__ = 605;
             validate_non_negative_index("rep_phi", "model_type", model_type);
             num_params_r__ += (1 * model_type);
         } catch (const std::exception& e) {
@@ -2759,7 +2811,7 @@ public:
         (void) pos__; // dummy call to supress warning
         std::vector<double> vals_r__;
         std::vector<int> vals_i__;
-        current_statement_begin__ = 579;
+        current_statement_begin__ = 587;
         if (!(context__.contains_r("rho")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable rho missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("rho");
@@ -2779,7 +2831,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable rho: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 580;
+        current_statement_begin__ = 588;
         if (!(context__.contains_r("alpha")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable alpha missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("alpha");
@@ -2799,7 +2851,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable alpha: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 581;
+        current_statement_begin__ = 589;
         if (!(context__.contains_r("eta")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable eta missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("eta");
@@ -2816,7 +2868,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable eta: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 583;
+        current_statement_begin__ = 591;
         if (!(context__.contains_r("log_R")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable log_R missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("log_R");
@@ -2833,7 +2885,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable log_R: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 584;
+        current_statement_begin__ = 592;
         if (!(context__.contains_r("initial_infections")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable initial_infections missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("initial_infections");
@@ -2853,7 +2905,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable initial_infections: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 585;
+        current_statement_begin__ = 593;
         if (!(context__.contains_r("initial_growth")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable initial_growth missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("initial_growth");
@@ -2873,7 +2925,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable initial_growth: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 586;
+        current_statement_begin__ = 594;
         if (!(context__.contains_r("gt_mean")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable gt_mean missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("gt_mean");
@@ -2893,7 +2945,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable gt_mean: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 587;
+        current_statement_begin__ = 595;
         if (!(context__.contains_r("gt_sd")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable gt_sd missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("gt_sd");
@@ -2913,7 +2965,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable gt_sd: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 588;
+        current_statement_begin__ = 596;
         if (!(context__.contains_r("bp_sd")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable bp_sd missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("bp_sd");
@@ -2933,7 +2985,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable bp_sd: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 589;
+        current_statement_begin__ = 597;
         if (!(context__.contains_r("bp_effects")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable bp_effects missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("bp_effects");
@@ -2953,7 +3005,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable bp_effects: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 591;
+        current_statement_begin__ = 599;
         if (!(context__.contains_r("delay_mean")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable delay_mean missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("delay_mean");
@@ -2973,7 +3025,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable delay_mean: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 592;
+        current_statement_begin__ = 600;
         if (!(context__.contains_r("delay_sd")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable delay_sd missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("delay_sd");
@@ -2993,7 +3045,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable delay_sd: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 593;
+        current_statement_begin__ = 601;
         if (!(context__.contains_r("day_of_week_simplex")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable day_of_week_simplex missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("day_of_week_simplex");
@@ -3010,7 +3062,7 @@ public:
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable day_of_week_simplex: ") + e.what()), current_statement_begin__, prog_reader__());
         }
-        current_statement_begin__ = 594;
+        current_statement_begin__ = 602;
         if (!(context__.contains_r("frac_obs")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable frac_obs missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("frac_obs");
@@ -3030,7 +3082,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable frac_obs: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 595;
+        current_statement_begin__ = 603;
         if (!(context__.contains_r("truncation_mean")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable truncation_mean missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("truncation_mean");
@@ -3050,7 +3102,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable truncation_mean: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 596;
+        current_statement_begin__ = 604;
         if (!(context__.contains_r("truncation_sd")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable truncation_sd missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("truncation_sd");
@@ -3070,7 +3122,7 @@ public:
                 stan::lang::rethrow_located(std::runtime_error(std::string("Error transforming variable truncation_sd: ") + e.what()), current_statement_begin__, prog_reader__());
             }
         }
-        current_statement_begin__ = 597;
+        current_statement_begin__ = 605;
         if (!(context__.contains_r("rep_phi")))
             stan::lang::rethrow_located(std::runtime_error(std::string("Variable rep_phi missing")), current_statement_begin__, prog_reader__());
         vals_r__ = context__.vals_r("rep_phi");
@@ -3115,7 +3167,7 @@ public:
         try {
             stan::io::reader<local_scalar_t__> in__(params_r__, params_i__);
             // model parameters
-            current_statement_begin__ = 579;
+            current_statement_begin__ = 587;
             std::vector<local_scalar_t__> rho;
             size_t rho_d_0_max__ = (fixed ? 0 : 1 );
             rho.reserve(rho_d_0_max__);
@@ -3125,7 +3177,7 @@ public:
                 else
                     rho.push_back(in__.scalar_lub_constrain(ls_min, ls_max));
             }
-            current_statement_begin__ = 580;
+            current_statement_begin__ = 588;
             std::vector<local_scalar_t__> alpha;
             size_t alpha_d_0_max__ = (fixed ? 0 : 1 );
             alpha.reserve(alpha_d_0_max__);
@@ -3135,21 +3187,21 @@ public:
                 else
                     alpha.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 581;
+            current_statement_begin__ = 589;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> eta;
             (void) eta;  // dummy to suppress unused var warning
             if (jacobian__)
                 eta = in__.vector_constrain((fixed ? 0 : M ), lp__);
             else
                 eta = in__.vector_constrain((fixed ? 0 : M ));
-            current_statement_begin__ = 583;
+            current_statement_begin__ = 591;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> log_R;
             (void) log_R;  // dummy to suppress unused var warning
             if (jacobian__)
                 log_R = in__.vector_constrain(estimate_r, lp__);
             else
                 log_R = in__.vector_constrain(estimate_r);
-            current_statement_begin__ = 584;
+            current_statement_begin__ = 592;
             std::vector<local_scalar_t__> initial_infections;
             size_t initial_infections_d_0_max__ = estimate_r;
             initial_infections.reserve(initial_infections_d_0_max__);
@@ -3159,7 +3211,7 @@ public:
                 else
                     initial_infections.push_back(in__.scalar_constrain());
             }
-            current_statement_begin__ = 585;
+            current_statement_begin__ = 593;
             std::vector<local_scalar_t__> initial_growth;
             size_t initial_growth_d_0_max__ = ((primitive_value(estimate_r) && primitive_value(logical_gt(seeding_time, 1))) ? 1 : 0 );
             initial_growth.reserve(initial_growth_d_0_max__);
@@ -3169,7 +3221,7 @@ public:
                 else
                     initial_growth.push_back(in__.scalar_constrain());
             }
-            current_statement_begin__ = 586;
+            current_statement_begin__ = 594;
             std::vector<local_scalar_t__> gt_mean;
             size_t gt_mean_d_0_max__ = estimate_r;
             gt_mean.reserve(gt_mean_d_0_max__);
@@ -3179,7 +3231,7 @@ public:
                 else
                     gt_mean.push_back(in__.scalar_lub_constrain(0, max_gt));
             }
-            current_statement_begin__ = 587;
+            current_statement_begin__ = 595;
             std::vector<local_scalar_t__> gt_sd;
             size_t gt_sd_d_0_max__ = estimate_r;
             gt_sd.reserve(gt_sd_d_0_max__);
@@ -3189,7 +3241,7 @@ public:
                 else
                     gt_sd.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 588;
+            current_statement_begin__ = 596;
             std::vector<local_scalar_t__> bp_sd;
             size_t bp_sd_d_0_max__ = (logical_gt(bp_n, 0) ? 1 : 0 );
             bp_sd.reserve(bp_sd_d_0_max__);
@@ -3199,7 +3251,7 @@ public:
                 else
                     bp_sd.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 589;
+            current_statement_begin__ = 597;
             std::vector<local_scalar_t__> bp_effects;
             size_t bp_effects_d_0_max__ = bp_n;
             bp_effects.reserve(bp_effects_d_0_max__);
@@ -3209,7 +3261,7 @@ public:
                 else
                     bp_effects.push_back(in__.scalar_constrain());
             }
-            current_statement_begin__ = 591;
+            current_statement_begin__ = 599;
             std::vector<local_scalar_t__> delay_mean;
             size_t delay_mean_d_0_max__ = delays;
             delay_mean.reserve(delay_mean_d_0_max__);
@@ -3219,7 +3271,7 @@ public:
                 else
                     delay_mean.push_back(in__.scalar_constrain());
             }
-            current_statement_begin__ = 592;
+            current_statement_begin__ = 600;
             std::vector<local_scalar_t__> delay_sd;
             size_t delay_sd_d_0_max__ = delays;
             delay_sd.reserve(delay_sd_d_0_max__);
@@ -3229,14 +3281,14 @@ public:
                 else
                     delay_sd.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 593;
+            current_statement_begin__ = 601;
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> day_of_week_simplex;
             (void) day_of_week_simplex;  // dummy to suppress unused var warning
             if (jacobian__)
                 day_of_week_simplex = in__.simplex_constrain((week_effect ? 7 : 1 ), lp__);
             else
                 day_of_week_simplex = in__.simplex_constrain((week_effect ? 7 : 1 ));
-            current_statement_begin__ = 594;
+            current_statement_begin__ = 602;
             std::vector<local_scalar_t__> frac_obs;
             size_t frac_obs_d_0_max__ = obs_scale;
             frac_obs.reserve(frac_obs_d_0_max__);
@@ -3246,7 +3298,7 @@ public:
                 else
                     frac_obs.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 595;
+            current_statement_begin__ = 603;
             std::vector<local_scalar_t__> truncation_mean;
             size_t truncation_mean_d_0_max__ = truncation;
             truncation_mean.reserve(truncation_mean_d_0_max__);
@@ -3256,7 +3308,7 @@ public:
                 else
                     truncation_mean.push_back(in__.scalar_constrain());
             }
-            current_statement_begin__ = 596;
+            current_statement_begin__ = 604;
             std::vector<local_scalar_t__> truncation_sd;
             size_t truncation_sd_d_0_max__ = truncation;
             truncation_sd.reserve(truncation_sd_d_0_max__);
@@ -3266,7 +3318,7 @@ public:
                 else
                     truncation_sd.push_back(in__.scalar_lb_constrain(0));
             }
-            current_statement_begin__ = 597;
+            current_statement_begin__ = 605;
             std::vector<local_scalar_t__> rep_phi;
             size_t rep_phi_d_0_max__ = model_type;
             rep_phi.reserve(rep_phi_d_0_max__);
@@ -3277,65 +3329,65 @@ public:
                     rep_phi.push_back(in__.scalar_lb_constrain(0));
             }
             // transformed parameters
-            current_statement_begin__ = 601;
+            current_statement_begin__ = 609;
             validate_non_negative_index("noise", "(fixed ? 0 : noise_terms )", (fixed ? 0 : noise_terms ));
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> noise((fixed ? 0 : noise_terms ));
             stan::math::initialize(noise, DUMMY_VAR__);
             stan::math::fill(noise, DUMMY_VAR__);
-            current_statement_begin__ = 602;
+            current_statement_begin__ = 610;
             validate_non_negative_index("R", "(logical_gt(estimate_r, 0) ? ot_h : 0 )", (logical_gt(estimate_r, 0) ? ot_h : 0 ));
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> R((logical_gt(estimate_r, 0) ? ot_h : 0 ));
             stan::math::initialize(R, DUMMY_VAR__);
             stan::math::fill(R, DUMMY_VAR__);
-            current_statement_begin__ = 603;
+            current_statement_begin__ = 611;
             validate_non_negative_index("infections", "t", t);
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> infections(t);
             stan::math::initialize(infections, DUMMY_VAR__);
             stan::math::fill(infections, DUMMY_VAR__);
-            current_statement_begin__ = 604;
+            current_statement_begin__ = 612;
             validate_non_negative_index("reports", "ot_h", ot_h);
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> reports(ot_h);
             stan::math::initialize(reports, DUMMY_VAR__);
             stan::math::fill(reports, DUMMY_VAR__);
-            current_statement_begin__ = 605;
+            current_statement_begin__ = 613;
             validate_non_negative_index("obs_reports", "ot", ot);
             Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> obs_reports(ot);
             stan::math::initialize(obs_reports, DUMMY_VAR__);
             stan::math::fill(obs_reports, DUMMY_VAR__);
             // transformed parameters block statements
-            current_statement_begin__ = 607;
+            current_statement_begin__ = 615;
             if (as_bool(logical_negation(fixed))) {
-                current_statement_begin__ = 608;
+                current_statement_begin__ = 616;
                 stan::math::assign(noise, update_gp(PHI, M, L, get_base1(alpha, 1, "alpha", 1), get_base1(rho, 1, "rho", 1), eta, gp_type, pstream__));
             }
-            current_statement_begin__ = 611;
+            current_statement_begin__ = 619;
             if (as_bool(estimate_r)) {
-                current_statement_begin__ = 613;
+                current_statement_begin__ = 621;
                 stan::math::assign(R, update_Rt(R, get_base1(log_R, estimate_r, "log_R", 1), noise, breakpoints, bp_effects, stationary, pstream__));
-                current_statement_begin__ = 614;
+                current_statement_begin__ = 622;
                 stan::math::assign(infections, generate_infections(R, seeding_time, gt_mean, gt_sd, max_gt, initial_infections, initial_growth, pop, future_time, pstream__));
             } else {
-                current_statement_begin__ = 619;
+                current_statement_begin__ = 627;
                 stan::math::assign(infections, deconvolve_infections(shifted_cases, noise, fixed, backcalc_prior, pstream__));
             }
-            current_statement_begin__ = 622;
+            current_statement_begin__ = 630;
             stan::math::assign(reports, convolve_to_report(infections, delay_mean, delay_sd, max_delay, seeding_time, pstream__));
-            current_statement_begin__ = 624;
+            current_statement_begin__ = 632;
             if (as_bool(week_effect)) {
-                current_statement_begin__ = 625;
+                current_statement_begin__ = 633;
                 stan::math::assign(reports, day_of_week_effect(reports, day_of_week, day_of_week_simplex, pstream__));
             }
-            current_statement_begin__ = 628;
+            current_statement_begin__ = 636;
             if (as_bool(obs_scale)) {
-                current_statement_begin__ = 629;
+                current_statement_begin__ = 637;
                 stan::math::assign(reports, scale_obs(reports, get_base1(frac_obs, 1, "frac_obs", 1), pstream__));
             }
-            current_statement_begin__ = 632;
+            current_statement_begin__ = 640;
             stan::math::assign(obs_reports, truncate(stan::model::rvalue(reports, stan::model::cons_list(stan::model::index_min_max(1, ot), stan::model::nil_index_list()), "reports"), truncation_mean, truncation_sd, max_truncation, 0, pstream__));
             // validate transformed parameters
             const char* function__ = "validate transformed params";
             (void) function__;  // dummy to suppress unused var warning
-            current_statement_begin__ = 601;
+            current_statement_begin__ = 609;
             size_t noise_j_1_max__ = (fixed ? 0 : noise_terms );
             for (size_t j_1__ = 0; j_1__ < noise_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(noise(j_1__))) {
@@ -3344,7 +3396,7 @@ public:
                     stan::lang::rethrow_located(std::runtime_error(std::string("Error initializing variable noise: ") + msg__.str()), current_statement_begin__, prog_reader__());
                 }
             }
-            current_statement_begin__ = 602;
+            current_statement_begin__ = 610;
             size_t R_j_1_max__ = (logical_gt(estimate_r, 0) ? ot_h : 0 );
             for (size_t j_1__ = 0; j_1__ < R_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(R(j_1__))) {
@@ -3354,7 +3406,7 @@ public:
                 }
             }
             check_less_or_equal(function__, "R", R, (10 * r_mean));
-            current_statement_begin__ = 603;
+            current_statement_begin__ = 611;
             size_t infections_j_1_max__ = t;
             for (size_t j_1__ = 0; j_1__ < infections_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(infections(j_1__))) {
@@ -3363,7 +3415,7 @@ public:
                     stan::lang::rethrow_located(std::runtime_error(std::string("Error initializing variable infections: ") + msg__.str()), current_statement_begin__, prog_reader__());
                 }
             }
-            current_statement_begin__ = 604;
+            current_statement_begin__ = 612;
             size_t reports_j_1_max__ = ot_h;
             for (size_t j_1__ = 0; j_1__ < reports_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(reports(j_1__))) {
@@ -3372,7 +3424,7 @@ public:
                     stan::lang::rethrow_located(std::runtime_error(std::string("Error initializing variable reports: ") + msg__.str()), current_statement_begin__, prog_reader__());
                 }
             }
-            current_statement_begin__ = 605;
+            current_statement_begin__ = 613;
             size_t obs_reports_j_1_max__ = ot;
             for (size_t j_1__ = 0; j_1__ < obs_reports_j_1_max__; ++j_1__) {
                 if (stan::math::is_uninitialized(obs_reports(j_1__))) {
@@ -3382,30 +3434,30 @@ public:
                 }
             }
             // model body
-            current_statement_begin__ = 637;
+            current_statement_begin__ = 645;
             if (as_bool(logical_negation(fixed))) {
-                current_statement_begin__ = 638;
+                current_statement_begin__ = 646;
                 gaussian_process_lp(get_base1(rho, 1, "rho", 1), get_base1(alpha, 1, "alpha", 1), eta, ls_meanlog, ls_sdlog, ls_min, ls_max, alpha_sd, lp__, lp_accum__, pstream__);
             }
-            current_statement_begin__ = 642;
+            current_statement_begin__ = 650;
             delays_lp(delay_mean, delay_mean_mean, delay_mean_sd, delay_sd, delay_sd_mean, delay_sd_sd, t, lp__, lp_accum__, pstream__);
-            current_statement_begin__ = 644;
+            current_statement_begin__ = 652;
             truncation_lp(truncation_mean, truncation_sd, trunc_mean_mean, trunc_mean_sd, trunc_sd_mean, trunc_sd_sd, lp__, lp_accum__, pstream__);
-            current_statement_begin__ = 646;
+            current_statement_begin__ = 654;
             if (as_bool(estimate_r)) {
-                current_statement_begin__ = 648;
+                current_statement_begin__ = 656;
                 rt_lp(log_R, initial_infections, initial_growth, bp_effects, bp_sd, bp_n, seeding_time, r_logmean, r_logsd, prior_infections, prior_growth, lp__, lp_accum__, pstream__);
-                current_statement_begin__ = 651;
+                current_statement_begin__ = 659;
                 generation_time_lp(gt_mean, gt_mean_mean, gt_mean_sd, gt_sd, gt_sd_mean, gt_sd_sd, ot, lp__, lp_accum__, pstream__);
             }
-            current_statement_begin__ = 654;
+            current_statement_begin__ = 662;
             if (as_bool(obs_scale)) {
-                current_statement_begin__ = 655;
+                current_statement_begin__ = 663;
                 lp_accum__.add(normal_log<propto__>(get_base1(frac_obs, 1, "frac_obs", 1), obs_scale_mean, obs_scale_sd));
                 if (get_base1(frac_obs, 1, "frac_obs", 1) < 0) lp_accum__.add(-std::numeric_limits<double>::infinity());
                 else lp_accum__.add(-normal_ccdf_log(0, obs_scale_mean, obs_scale_sd));
             }
-            current_statement_begin__ = 658;
+            current_statement_begin__ = 666;
             report_lp(cases, obs_reports, rep_phi, 1, model_type, obs_weight, lp__, lp_accum__, pstream__);
         } catch (const std::exception& e) {
             stan::lang::rethrow_located(e, current_statement_begin__, prog_reader__());
@@ -3530,7 +3582,7 @@ public:
         dims__.push_back((logical_gt(estimate_r, 0) ? 0 : ot_h ));
         dimss__.push_back(dims__);
         dims__.resize(0);
-        dims__.push_back(ot_h);
+        dims__.push_back((ot_h - 1));
         dimss__.push_back(dims__);
         dims__.resize(0);
         dims__.push_back(ot);
@@ -3713,66 +3765,66 @@ public:
         if (!include_tparams__ && !include_gqs__) return;
         try {
             // declare and define transformed parameters
-            current_statement_begin__ = 601;
+            current_statement_begin__ = 609;
             validate_non_negative_index("noise", "(fixed ? 0 : noise_terms )", (fixed ? 0 : noise_terms ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> noise((fixed ? 0 : noise_terms ));
             stan::math::initialize(noise, DUMMY_VAR__);
             stan::math::fill(noise, DUMMY_VAR__);
-            current_statement_begin__ = 602;
+            current_statement_begin__ = 610;
             validate_non_negative_index("R", "(logical_gt(estimate_r, 0) ? ot_h : 0 )", (logical_gt(estimate_r, 0) ? ot_h : 0 ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> R((logical_gt(estimate_r, 0) ? ot_h : 0 ));
             stan::math::initialize(R, DUMMY_VAR__);
             stan::math::fill(R, DUMMY_VAR__);
-            current_statement_begin__ = 603;
+            current_statement_begin__ = 611;
             validate_non_negative_index("infections", "t", t);
             Eigen::Matrix<double, Eigen::Dynamic, 1> infections(t);
             stan::math::initialize(infections, DUMMY_VAR__);
             stan::math::fill(infections, DUMMY_VAR__);
-            current_statement_begin__ = 604;
+            current_statement_begin__ = 612;
             validate_non_negative_index("reports", "ot_h", ot_h);
             Eigen::Matrix<double, Eigen::Dynamic, 1> reports(ot_h);
             stan::math::initialize(reports, DUMMY_VAR__);
             stan::math::fill(reports, DUMMY_VAR__);
-            current_statement_begin__ = 605;
+            current_statement_begin__ = 613;
             validate_non_negative_index("obs_reports", "ot", ot);
             Eigen::Matrix<double, Eigen::Dynamic, 1> obs_reports(ot);
             stan::math::initialize(obs_reports, DUMMY_VAR__);
             stan::math::fill(obs_reports, DUMMY_VAR__);
             // do transformed parameters statements
-            current_statement_begin__ = 607;
+            current_statement_begin__ = 615;
             if (as_bool(logical_negation(fixed))) {
-                current_statement_begin__ = 608;
+                current_statement_begin__ = 616;
                 stan::math::assign(noise, update_gp(PHI, M, L, get_base1(alpha, 1, "alpha", 1), get_base1(rho, 1, "rho", 1), eta, gp_type, pstream__));
             }
-            current_statement_begin__ = 611;
+            current_statement_begin__ = 619;
             if (as_bool(estimate_r)) {
-                current_statement_begin__ = 613;
+                current_statement_begin__ = 621;
                 stan::math::assign(R, update_Rt(R, get_base1(log_R, estimate_r, "log_R", 1), noise, breakpoints, bp_effects, stationary, pstream__));
-                current_statement_begin__ = 614;
+                current_statement_begin__ = 622;
                 stan::math::assign(infections, generate_infections(R, seeding_time, gt_mean, gt_sd, max_gt, initial_infections, initial_growth, pop, future_time, pstream__));
             } else {
-                current_statement_begin__ = 619;
+                current_statement_begin__ = 627;
                 stan::math::assign(infections, deconvolve_infections(shifted_cases, noise, fixed, backcalc_prior, pstream__));
             }
-            current_statement_begin__ = 622;
+            current_statement_begin__ = 630;
             stan::math::assign(reports, convolve_to_report(infections, delay_mean, delay_sd, max_delay, seeding_time, pstream__));
-            current_statement_begin__ = 624;
+            current_statement_begin__ = 632;
             if (as_bool(week_effect)) {
-                current_statement_begin__ = 625;
+                current_statement_begin__ = 633;
                 stan::math::assign(reports, day_of_week_effect(reports, day_of_week, day_of_week_simplex, pstream__));
             }
-            current_statement_begin__ = 628;
+            current_statement_begin__ = 636;
             if (as_bool(obs_scale)) {
-                current_statement_begin__ = 629;
+                current_statement_begin__ = 637;
                 stan::math::assign(reports, scale_obs(reports, get_base1(frac_obs, 1, "frac_obs", 1), pstream__));
             }
-            current_statement_begin__ = 632;
+            current_statement_begin__ = 640;
             stan::math::assign(obs_reports, truncate(stan::model::rvalue(reports, stan::model::cons_list(stan::model::index_min_max(1, ot), stan::model::nil_index_list()), "reports"), truncation_mean, truncation_sd, max_truncation, 0, pstream__));
             if (!include_gqs__ && !include_tparams__) return;
             // validate transformed parameters
             const char* function__ = "validate transformed params";
             (void) function__;  // dummy to suppress unused var warning
-            current_statement_begin__ = 602;
+            current_statement_begin__ = 610;
             check_less_or_equal(function__, "R", R, (10 * r_mean));
             // write transformed parameters
             if (include_tparams__) {
@@ -3799,71 +3851,68 @@ public:
             }
             if (!include_gqs__) return;
             // declare and define generated quantities
-            current_statement_begin__ = 662;
+            current_statement_begin__ = 670;
             validate_non_negative_index("imputed_reports", "ot_h", ot_h);
             std::vector<int> imputed_reports(ot_h, int(0));
             stan::math::fill(imputed_reports, std::numeric_limits<int>::min());
-            current_statement_begin__ = 663;
+            current_statement_begin__ = 671;
             validate_non_negative_index("gen_R", "(logical_gt(estimate_r, 0) ? 0 : ot_h )", (logical_gt(estimate_r, 0) ? 0 : ot_h ));
             Eigen::Matrix<double, Eigen::Dynamic, 1> gen_R((logical_gt(estimate_r, 0) ? 0 : ot_h ));
             stan::math::initialize(gen_R, DUMMY_VAR__);
             stan::math::fill(gen_R, DUMMY_VAR__);
-            current_statement_begin__ = 664;
-            validate_non_negative_index("r", "ot_h", ot_h);
-            std::vector<double> r(ot_h, double(0));
+            current_statement_begin__ = 672;
+            validate_non_negative_index("r", "(ot_h - 1)", (ot_h - 1));
+            std::vector<double> r((ot_h - 1), double(0));
             stan::math::initialize(r, DUMMY_VAR__);
             stan::math::fill(r, DUMMY_VAR__);
-            current_statement_begin__ = 665;
+            current_statement_begin__ = 673;
             validate_non_negative_index("log_lik", "ot", ot);
             Eigen::Matrix<double, Eigen::Dynamic, 1> log_lik(ot);
             stan::math::initialize(log_lik, DUMMY_VAR__);
             stan::math::fill(log_lik, DUMMY_VAR__);
             // generated quantities statements
-            current_statement_begin__ = 666;
-            if (as_bool(estimate_r)) {
-                current_statement_begin__ = 668;
-                stan::math::assign(r, R_to_growth(R, get_base1(gt_mean, 1, "gt_mean", 1), get_base1(gt_sd, 1, "gt_sd", 1), pstream__));
-            } else {
+            current_statement_begin__ = 674;
+            if (as_bool(logical_eq(estimate_r, 0))) {
                 {
-                current_statement_begin__ = 671;
+                current_statement_begin__ = 676;
                 local_scalar_t__ gt_mean_sample(DUMMY_VAR__);
                 (void) gt_mean_sample;  // dummy to suppress unused var warning
                 stan::math::initialize(gt_mean_sample, DUMMY_VAR__);
                 stan::math::fill(gt_mean_sample, DUMMY_VAR__);
                 stan::math::assign(gt_mean_sample,normal_rng(gt_mean_mean, gt_mean_sd, base_rng__));
-                current_statement_begin__ = 672;
+                current_statement_begin__ = 677;
                 local_scalar_t__ gt_sd_sample(DUMMY_VAR__);
                 (void) gt_sd_sample;  // dummy to suppress unused var warning
                 stan::math::initialize(gt_sd_sample, DUMMY_VAR__);
                 stan::math::fill(gt_sd_sample, DUMMY_VAR__);
                 stan::math::assign(gt_sd_sample,normal_rng(gt_sd_mean, gt_sd_sd, base_rng__));
-                current_statement_begin__ = 674;
+                current_statement_begin__ = 679;
                 stan::math::assign(gen_R, calculate_Rt(infections, seeding_time, gt_mean_sample, gt_mean_sample, max_gt, rt_half_window, pstream__));
-                current_statement_begin__ = 677;
-                stan::math::assign(r, R_to_growth(gen_R, gt_mean_sample, gt_sd_sample, pstream__));
                 }
             }
-            current_statement_begin__ = 680;
+            current_statement_begin__ = 683;
+            stan::math::assign(r, calculate_growth(infections, (seeding_time + 1), pstream__));
+            current_statement_begin__ = 685;
             stan::math::assign(imputed_reports, report_rng(reports, rep_phi, model_type, base_rng__, pstream__));
-            current_statement_begin__ = 682;
+            current_statement_begin__ = 687;
             stan::math::assign(log_lik, report_log_lik(cases, obs_reports, rep_phi, model_type, obs_weight, pstream__));
             // validate, write generated quantities
-            current_statement_begin__ = 662;
+            current_statement_begin__ = 670;
             size_t imputed_reports_k_0_max__ = ot_h;
             for (size_t k_0__ = 0; k_0__ < imputed_reports_k_0_max__; ++k_0__) {
                 vars__.push_back(imputed_reports[k_0__]);
             }
-            current_statement_begin__ = 663;
+            current_statement_begin__ = 671;
             size_t gen_R_j_1_max__ = (logical_gt(estimate_r, 0) ? 0 : ot_h );
             for (size_t j_1__ = 0; j_1__ < gen_R_j_1_max__; ++j_1__) {
                 vars__.push_back(gen_R(j_1__));
             }
-            current_statement_begin__ = 664;
-            size_t r_k_0_max__ = ot_h;
+            current_statement_begin__ = 672;
+            size_t r_k_0_max__ = (ot_h - 1);
             for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
                 vars__.push_back(r[k_0__]);
             }
-            current_statement_begin__ = 665;
+            current_statement_begin__ = 673;
             size_t log_lik_j_1_max__ = ot;
             for (size_t j_1__ = 0; j_1__ < log_lik_j_1_max__; ++j_1__) {
                 vars__.push_back(log_lik(j_1__));
@@ -4046,7 +4095,7 @@ public:
             param_name_stream__ << "gen_R" << '.' << j_1__ + 1;
             param_names__.push_back(param_name_stream__.str());
         }
-        size_t r_k_0_max__ = ot_h;
+        size_t r_k_0_max__ = (ot_h - 1);
         for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
             param_name_stream__.str(std::string());
             param_name_stream__ << "r" << '.' << k_0__ + 1;
@@ -4211,7 +4260,7 @@ public:
             param_name_stream__ << "gen_R" << '.' << j_1__ + 1;
             param_names__.push_back(param_name_stream__.str());
         }
-        size_t r_k_0_max__ = ot_h;
+        size_t r_k_0_max__ = (ot_h - 1);
         for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
             param_name_stream__.str(std::string());
             param_name_stream__ << "r" << '.' << k_0__ + 1;

--- a/src/stanExports_estimate_secondary.h
+++ b/src/stanExports_estimate_secondary.h
@@ -143,9 +143,9 @@ discretised_gamma_pmf(const std::vector<int>& y,
         current_statement_begin__ = 21;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 22;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 25;
@@ -249,9 +249,9 @@ discretised_lognormal_pmf(const std::vector<int>& y,
         current_statement_begin__ = 41;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 42;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 45;
@@ -294,9 +294,9 @@ reverse_mf(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& pmf,
         current_statement_begin__ = 51;
         for (int d = 1; d <= max_pmf; ++d) {
             current_statement_begin__ = 52;
-            stan::model::assign(rev_pmf,
-                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()),
-                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1),
+            stan::model::assign(rev_pmf, 
+                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()), 
+                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1), 
                         "assigning variable rev_pmf");
         }
         current_statement_begin__ = 54;
@@ -348,9 +348,9 @@ convolve(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& cases,
         current_statement_begin__ = 61;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 62;
-            stan::model::assign(conv_cases,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))),
+            stan::model::assign(conv_cases, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))), 
                         "assigning variable conv_cases");
         }
         current_statement_begin__ = 65;
@@ -425,9 +425,9 @@ convolve_to_report(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 current_statement_begin__ = 83;
                 for (int i = 1; i <= get_base1(max_delay, s, "max_delay", 1); ++i) {
                     current_statement_begin__ = 84;
-                    stan::model::assign(delay_indexes,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(max_delay, s, "max_delay", 1) - i),
+                    stan::model::assign(delay_indexes, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(max_delay, s, "max_delay", 1) - i), 
                                 "assigning variable delay_indexes");
                 }
                 current_statement_begin__ = 86;
@@ -548,9 +548,9 @@ day_of_week_effect(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
         current_statement_begin__ = 113;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 115;
-            stan::model::assign(scaled_reports,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)),
+            stan::model::assign(scaled_reports, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)), 
                         "assigning variable scaled_reports");
         }
         current_statement_begin__ = 117;
@@ -639,17 +639,17 @@ truncation_cmf(const T0__& trunc_mean,
         current_statement_begin__ = 131;
         for (int i = 1; i <= trunc_max; ++i) {
             current_statement_begin__ = 132;
-            stan::model::assign(trunc_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (i - 1),
+            stan::model::assign(trunc_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (i - 1), 
                         "assigning variable trunc_indexes");
         }
         current_statement_begin__ = 134;
         stan::math::assign(cmf, discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max, pstream__));
         current_statement_begin__ = 135;
-        stan::model::assign(cmf,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (get_base1(cmf, 1, "cmf", 1) + 1e-8),
+        stan::model::assign(cmf, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (get_base1(cmf, 1, "cmf", 1) + 1e-8), 
                     "assigning variable cmf");
         current_statement_begin__ = 136;
         stan::math::assign(cmf, cumulative_sum(cmf));
@@ -732,15 +732,15 @@ truncate(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 154;
             if (as_bool(reconstruct)) {
                 current_statement_begin__ = 155;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             } else {
                 current_statement_begin__ = 157;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             }
             }
@@ -914,18 +914,18 @@ report_log_lik(const std::vector<int>& cases,
                 current_statement_begin__ = 201;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 202;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                                 "assigning variable log_lik");
                 }
             } else {
                 current_statement_begin__ = 205;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 206;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight), 
                                 "assigning variable log_lik");
                 }
             }
@@ -934,9 +934,9 @@ report_log_lik(const std::vector<int>& cases,
             current_statement_begin__ = 210;
             for (int i = 1; i <= t; ++i) {
                 current_statement_begin__ = 211;
-                stan::model::assign(log_lik,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                stan::model::assign(log_lik, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                             "assigning variable log_lik");
             }
         }
@@ -997,15 +997,15 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 225;
                 if (as_bool(logical_gt(sqrt_phi, 1e4))) {
                     current_statement_begin__ = 226;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                                 "assigning variable sampled_reports");
                 } else {
                     current_statement_begin__ = 228;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__), 
                                 "assigning variable sampled_reports");
                 }
             }
@@ -1013,9 +1013,9 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 232;
             for (int s = 1; s <= t; ++s) {
                 current_statement_begin__ = 233;
-                stan::model::assign(sampled_reports,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                stan::model::assign(sampled_reports, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                             "assigning variable sampled_reports");
             }
         }
@@ -1104,15 +1104,15 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 265;
                 if (as_bool(logical_gt(i, predict))) {
                     current_statement_begin__ = 266;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                get_base1(secondary_reports, (i - 1), "secondary_reports", 1),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                get_base1(secondary_reports, (i - 1), "secondary_reports", 1), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 268;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                get_base1(obs, (i - 1), "obs", 1),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                get_base1(obs, (i - 1), "obs", 1), 
                                 "assigning variable secondary_reports");
                 }
             }
@@ -1121,23 +1121,23 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 273;
                 if (as_bool(primary_hist_additive)) {
                     current_statement_begin__ = 274;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(conv_reports, i, "conv_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(conv_reports, i, "conv_reports", 1)), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 276;
                     if (as_bool(logical_gt(get_base1(conv_reports, i, "conv_reports", 1), get_base1(secondary_reports, i, "secondary_reports", 1)))) {
                         current_statement_begin__ = 277;
-                        stan::model::assign(conv_reports,
-                                    stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                    get_base1(secondary_reports, i, "secondary_reports", 1),
+                        stan::model::assign(conv_reports, 
+                                    stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                    get_base1(secondary_reports, i, "secondary_reports", 1), 
                                     "assigning variable conv_reports");
                     }
                     current_statement_begin__ = 279;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(conv_reports, i, "conv_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(conv_reports, i, "conv_reports", 1)), 
                                 "assigning variable secondary_reports");
                 }
             }
@@ -1146,22 +1146,22 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 284;
                 if (as_bool(primary_current_additive)) {
                     current_statement_begin__ = 285;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(scaled_reports, i, "scaled_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(scaled_reports, i, "scaled_reports", 1)), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 287;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(scaled_reports, i, "scaled_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(scaled_reports, i, "scaled_reports", 1)), 
                                 "assigning variable secondary_reports");
                 }
             }
             current_statement_begin__ = 290;
-            stan::model::assign(secondary_reports,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (logical_lte(get_base1(secondary_reports, i, "secondary_reports", 1), 0) ? stan::math::promote_scalar<local_scalar_t__>(1e-5) : stan::math::promote_scalar<local_scalar_t__>(get_base1(secondary_reports, i, "secondary_reports", 1)) ),
+            stan::model::assign(secondary_reports, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (logical_lte(get_base1(secondary_reports, i, "secondary_reports", 1), 0) ? stan::math::promote_scalar<local_scalar_t__>(1e-5) : stan::math::promote_scalar<local_scalar_t__>(get_base1(secondary_reports, i, "secondary_reports", 1)) ), 
                         "assigning variable secondary_reports");
         }
         current_statement_begin__ = 292;

--- a/src/stanExports_estimate_truncation.h
+++ b/src/stanExports_estimate_truncation.h
@@ -123,9 +123,9 @@ discretised_gamma_pmf(const std::vector<int>& y,
         current_statement_begin__ = 21;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 22;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 25;
@@ -229,9 +229,9 @@ discretised_lognormal_pmf(const std::vector<int>& y,
         current_statement_begin__ = 41;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 42;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 45;
@@ -274,9 +274,9 @@ reverse_mf(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& pmf,
         current_statement_begin__ = 51;
         for (int d = 1; d <= max_pmf; ++d) {
             current_statement_begin__ = 52;
-            stan::model::assign(rev_pmf,
-                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()),
-                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1),
+            stan::model::assign(rev_pmf, 
+                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()), 
+                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1), 
                         "assigning variable rev_pmf");
         }
         current_statement_begin__ = 54;
@@ -329,9 +329,9 @@ day_of_week_effect(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
         current_statement_begin__ = 62;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 64;
-            stan::model::assign(scaled_reports,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)),
+            stan::model::assign(scaled_reports, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)), 
                         "assigning variable scaled_reports");
         }
         current_statement_begin__ = 66;
@@ -420,17 +420,17 @@ truncation_cmf(const T0__& trunc_mean,
         current_statement_begin__ = 80;
         for (int i = 1; i <= trunc_max; ++i) {
             current_statement_begin__ = 81;
-            stan::model::assign(trunc_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (i - 1),
+            stan::model::assign(trunc_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (i - 1), 
                         "assigning variable trunc_indexes");
         }
         current_statement_begin__ = 83;
         stan::math::assign(cmf, discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max, pstream__));
         current_statement_begin__ = 84;
-        stan::model::assign(cmf,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (get_base1(cmf, 1, "cmf", 1) + 1e-8),
+        stan::model::assign(cmf, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (get_base1(cmf, 1, "cmf", 1) + 1e-8), 
                     "assigning variable cmf");
         current_statement_begin__ = 85;
         stan::math::assign(cmf, cumulative_sum(cmf));
@@ -513,15 +513,15 @@ truncate(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 103;
             if (as_bool(reconstruct)) {
                 current_statement_begin__ = 104;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             } else {
                 current_statement_begin__ = 106;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             }
             }
@@ -695,18 +695,18 @@ report_log_lik(const std::vector<int>& cases,
                 current_statement_begin__ = 150;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 151;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                                 "assigning variable log_lik");
                 }
             } else {
                 current_statement_begin__ = 154;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 155;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight), 
                                 "assigning variable log_lik");
                 }
             }
@@ -715,9 +715,9 @@ report_log_lik(const std::vector<int>& cases,
             current_statement_begin__ = 159;
             for (int i = 1; i <= t; ++i) {
                 current_statement_begin__ = 160;
-                stan::model::assign(log_lik,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                stan::model::assign(log_lik, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                             "assigning variable log_lik");
             }
         }
@@ -778,15 +778,15 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 174;
                 if (as_bool(logical_gt(sqrt_phi, 1e4))) {
                     current_statement_begin__ = 175;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                                 "assigning variable sampled_reports");
                 } else {
                     current_statement_begin__ = 177;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__), 
                                 "assigning variable sampled_reports");
                 }
             }
@@ -794,9 +794,9 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 181;
             for (int s = 1; s <= t; ++s) {
                 current_statement_begin__ = 182;
-                stan::model::assign(sampled_reports,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                stan::model::assign(sampled_reports, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                             "assigning variable sampled_reports");
             }
         }
@@ -1075,9 +1075,9 @@ public:
                 stan::math::fill(start_t, std::numeric_limits<int>::min());
                 stan::math::assign(start_t,((end_t - get_base1(trunc_max, 1, "trunc_max", 1)) + 1));
                 current_statement_begin__ = 213;
-                stan::model::assign(trunc_obs,
-                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())),
-                            truncate(stan::model::rvalue(last_obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::nil_index_list()), "last_obs"), logmean, logsd, trunc_max, 0, pstream__),
+                stan::model::assign(trunc_obs, 
+                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())), 
+                            truncate(stan::model::rvalue(last_obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::nil_index_list()), "last_obs"), logmean, logsd, trunc_max, 0, pstream__), 
                             "assigning variable trunc_obs");
                 }
             }
@@ -1261,9 +1261,9 @@ public:
                 stan::math::fill(start_t, std::numeric_limits<int>::min());
                 stan::math::assign(start_t,((end_t - get_base1(trunc_max, 1, "trunc_max", 1)) + 1));
                 current_statement_begin__ = 213;
-                stan::model::assign(trunc_obs,
-                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())),
-                            truncate(stan::model::rvalue(last_obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::nil_index_list()), "last_obs"), logmean, logsd, trunc_max, 0, pstream__),
+                stan::model::assign(trunc_obs, 
+                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())), 
+                            truncate(stan::model::rvalue(last_obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::nil_index_list()), "last_obs"), logmean, logsd, trunc_max, 0, pstream__), 
                             "assigning variable trunc_obs");
                 }
             }
@@ -1311,9 +1311,9 @@ public:
                 stan::math::fill(start_t, std::numeric_limits<int>::min());
                 stan::math::assign(start_t,((end_t - get_base1(trunc_max, 1, "trunc_max", 1)) + 1));
                 current_statement_begin__ = 237;
-                stan::model::assign(recon_obs,
-                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())),
-                            truncate(to_vector(stan::model::rvalue(obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())), "obs")), logmean, logsd, trunc_max, 1, pstream__),
+                stan::model::assign(recon_obs, 
+                            stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())), 
+                            truncate(to_vector(stan::model::rvalue(obs, stan::model::cons_list(stan::model::index_min_max(start_t, end_t), stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list())), "obs")), logmean, logsd, trunc_max, 1, pstream__), 
                             "assigning variable recon_obs");
                 }
             }

--- a/src/stanExports_simulate_infections.h
+++ b/src/stanExports_simulate_infections.h
@@ -59,21 +59,21 @@ stan::io::program_reader prog_reader__() {
     reader.add_event(460, 7, "restart", "model_simulate_infections");
     reader.add_event(460, 7, "include", "functions/generated_quantities.stan");
     reader.add_event(460, 0, "start", "functions/generated_quantities.stan");
-    reader.add_event(506, 46, "end", "functions/generated_quantities.stan");
-    reader.add_event(506, 8, "restart", "model_simulate_infections");
-    reader.add_event(515, 17, "include", "data/simulation_rt.stan");
-    reader.add_event(515, 0, "start", "data/simulation_rt.stan");
-    reader.add_event(522, 7, "end", "data/simulation_rt.stan");
-    reader.add_event(522, 18, "restart", "model_simulate_infections");
-    reader.add_event(523, 19, "include", "data/simulation_delays.stan");
-    reader.add_event(523, 0, "start", "data/simulation_delays.stan");
-    reader.add_event(527, 4, "end", "data/simulation_delays.stan");
-    reader.add_event(527, 20, "restart", "model_simulate_infections");
-    reader.add_event(528, 21, "include", "data/simulation_observation_model.stan");
-    reader.add_event(528, 0, "start", "data/simulation_observation_model.stan");
-    reader.add_event(535, 7, "end", "data/simulation_observation_model.stan");
-    reader.add_event(535, 22, "restart", "model_simulate_infections");
-    reader.add_event(568, 53, "end", "model_simulate_infections");
+    reader.add_event(514, 54, "end", "functions/generated_quantities.stan");
+    reader.add_event(514, 8, "restart", "model_simulate_infections");
+    reader.add_event(523, 17, "include", "data/simulation_rt.stan");
+    reader.add_event(523, 0, "start", "data/simulation_rt.stan");
+    reader.add_event(530, 7, "end", "data/simulation_rt.stan");
+    reader.add_event(530, 18, "restart", "model_simulate_infections");
+    reader.add_event(531, 19, "include", "data/simulation_delays.stan");
+    reader.add_event(531, 0, "start", "data/simulation_delays.stan");
+    reader.add_event(535, 4, "end", "data/simulation_delays.stan");
+    reader.add_event(535, 20, "restart", "model_simulate_infections");
+    reader.add_event(536, 21, "include", "data/simulation_observation_model.stan");
+    reader.add_event(536, 0, "start", "data/simulation_observation_model.stan");
+    reader.add_event(543, 7, "end", "data/simulation_observation_model.stan");
+    reader.add_event(543, 22, "restart", "model_simulate_infections");
+    reader.add_event(576, 53, "end", "model_simulate_infections");
     return reader;
 }
 template <typename T1__, typename T2__>
@@ -155,9 +155,9 @@ discretised_gamma_pmf(const std::vector<int>& y,
         current_statement_begin__ = 21;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 22;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 25;
@@ -261,9 +261,9 @@ discretised_lognormal_pmf(const std::vector<int>& y,
         current_statement_begin__ = 41;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 42;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 45;
@@ -306,9 +306,9 @@ reverse_mf(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& pmf,
         current_statement_begin__ = 51;
         for (int d = 1; d <= max_pmf; ++d) {
             current_statement_begin__ = 52;
-            stan::model::assign(rev_pmf,
-                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()),
-                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1),
+            stan::model::assign(rev_pmf, 
+                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()), 
+                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1), 
                         "assigning variable rev_pmf");
         }
         current_statement_begin__ = 54;
@@ -360,9 +360,9 @@ convolve(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& cases,
         current_statement_begin__ = 61;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 62;
-            stan::model::assign(conv_cases,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))),
+            stan::model::assign(conv_cases, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))), 
                         "assigning variable conv_cases");
         }
         current_statement_begin__ = 65;
@@ -437,9 +437,9 @@ convolve_to_report(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 current_statement_begin__ = 83;
                 for (int i = 1; i <= get_base1(max_delay, s, "max_delay", 1); ++i) {
                     current_statement_begin__ = 84;
-                    stan::model::assign(delay_indexes,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(max_delay, s, "max_delay", 1) - i),
+                    stan::model::assign(delay_indexes, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(max_delay, s, "max_delay", 1) - i), 
                                 "assigning variable delay_indexes");
                 }
                 current_statement_begin__ = 86;
@@ -763,17 +763,17 @@ setup_gp(const int& M,
         current_statement_begin__ = 145;
         for (int s = 1; s <= dimension; ++s) {
             current_statement_begin__ = 146;
-            stan::model::assign(time,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        ((s - half_dim) / half_dim),
+            stan::model::assign(time, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        ((s - half_dim) / half_dim), 
                         "assigning variable time");
         }
         current_statement_begin__ = 148;
         for (int m = 1; m <= M; ++m) {
             current_statement_begin__ = 149;
-            stan::model::assign(PHI,
-                        stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list())),
-                        phi(L, m, time, pstream__),
+            stan::model::assign(PHI, 
+                        stan::model::cons_list(stan::model::index_omni(), stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list())), 
+                        phi(L, m, time, pstream__), 
                         "assigning variable PHI");
         }
         current_statement_begin__ = 151;
@@ -844,18 +844,18 @@ update_gp(const Eigen::Matrix<T0__, Eigen::Dynamic, Eigen::Dynamic>& PHI,
             current_statement_begin__ = 163;
             for (int m = 1; m <= M; ++m) {
                 current_statement_begin__ = 164;
-                stan::model::assign(diagSPD,
-                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()),
-                            stan::math::sqrt(spd_se(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)),
+                stan::model::assign(diagSPD, 
+                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()), 
+                            stan::math::sqrt(spd_se(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)), 
                             "assigning variable diagSPD");
             }
         } else if (as_bool(logical_eq(type, 1))) {
             current_statement_begin__ = 167;
             for (int m = 1; m <= M; ++m) {
                 current_statement_begin__ = 168;
-                stan::model::assign(diagSPD,
-                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()),
-                            stan::math::sqrt(spd_matern(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)),
+                stan::model::assign(diagSPD, 
+                            stan::model::cons_list(stan::model::index_uni(m), stan::model::nil_index_list()), 
+                            stan::math::sqrt(spd_matern(alpha, unit_rho, stan::math::sqrt(lambda(L, m, pstream__)), pstream__)), 
                             "assigning variable diagSPD");
             }
         }
@@ -995,9 +995,9 @@ update_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& input_R,
                     current_statement_begin__ = 199;
                     stan::math::assign(bp_c, (bp_c + get_base1(bps, s, "bps", 1)));
                     current_statement_begin__ = 200;
-                    stan::model::assign(bp,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                get_base1(bp_effects, bp_c, "bp_effects", 1),
+                    stan::model::assign(bp, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                get_base1(bp_effects, bp_c, "bp_effects", 1), 
                                 "assigning variable bp");
                 }
             }
@@ -1009,23 +1009,23 @@ update_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& input_R,
             current_statement_begin__ = 207;
             if (as_bool(stationary)) {
                 current_statement_begin__ = 208;
-                stan::model::assign(gp,
-                            stan::model::cons_list(stan::model::index_min_max(1, gp_n), stan::model::nil_index_list()),
-                            noise,
+                stan::model::assign(gp, 
+                            stan::model::cons_list(stan::model::index_min_max(1, gp_n), stan::model::nil_index_list()), 
+                            noise, 
                             "assigning variable gp");
                 current_statement_begin__ = 210;
                 if (as_bool(logical_gt(t, gp_n))) {
                     current_statement_begin__ = 211;
-                    stan::model::assign(gp,
-                                stan::model::cons_list(stan::model::index_min_max((gp_n + 1), t), stan::model::nil_index_list()),
-                                rep_vector(get_base1(noise, gp_n, "noise", 1), (t - gp_n)),
+                    stan::model::assign(gp, 
+                                stan::model::cons_list(stan::model::index_min_max((gp_n + 1), t), stan::model::nil_index_list()), 
+                                rep_vector(get_base1(noise, gp_n, "noise", 1), (t - gp_n)), 
                                 "assigning variable gp");
                 }
             } else {
                 current_statement_begin__ = 214;
-                stan::model::assign(gp,
-                            stan::model::cons_list(stan::model::index_min_max(2, (gp_n + 1)), stan::model::nil_index_list()),
-                            noise,
+                stan::model::assign(gp, 
+                            stan::model::cons_list(stan::model::index_min_max(2, (gp_n + 1)), stan::model::nil_index_list()), 
+                            noise, 
                             "assigning variable gp");
                 current_statement_begin__ = 215;
                 stan::math::assign(gp, cumulative_sum(gp));
@@ -1252,43 +1252,43 @@ generate_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& oR,
         current_statement_begin__ = 268;
         for (int i = 1; i <= max_gt; ++i) {
             current_statement_begin__ = 269;
-            stan::model::assign(gt_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((max_gt - i) + 1),
+            stan::model::assign(gt_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((max_gt - i) + 1), 
                         "assigning variable gt_indexes");
         }
         current_statement_begin__ = 271;
         stan::math::assign(gt_pmf, add(gt_pmf, discretised_gamma_pmf(gt_indexes, get_base1(gt_mean, 1, "gt_mean", 1), get_base1(gt_sd, 1, "gt_sd", 1), max_gt, pstream__)));
         current_statement_begin__ = 273;
-        stan::model::assign(infections,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    stan::math::exp(get_base1(initial_infections, 1, "initial_infections", 1)),
+        stan::model::assign(infections, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    stan::math::exp(get_base1(initial_infections, 1, "initial_infections", 1)), 
                     "assigning variable infections");
         current_statement_begin__ = 274;
         if (as_bool(logical_gt(uot, 1))) {
             current_statement_begin__ = 275;
             for (int s = 2; s <= uot; ++s) {
                 current_statement_begin__ = 276;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            stan::math::exp((get_base1(initial_infections, 1, "initial_infections", 1) + (get_base1(initial_growth, 1, "initial_growth", 1) * (s - 1)))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            stan::math::exp((get_base1(initial_infections, 1, "initial_infections", 1) + (get_base1(initial_growth, 1, "initial_growth", 1) * (s - 1)))), 
                             "assigning variable infections");
             }
         }
         current_statement_begin__ = 280;
         if (as_bool(pop)) {
             current_statement_begin__ = 281;
-            stan::model::assign(cum_infections,
-                        stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                        sum(stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_min_max(1, uot), stan::model::nil_index_list()), "infections")),
+            stan::model::assign(cum_infections, 
+                        stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                        sum(stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_min_max(1, uot), stan::model::nil_index_list()), "infections")), 
                         "assigning variable cum_infections");
         }
         current_statement_begin__ = 284;
         for (int s = 1; s <= ot; ++s) {
             current_statement_begin__ = 285;
-            stan::model::assign(infectiousness,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, uot, max_gt, s, pstream__)),
+            stan::model::assign(infectiousness, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, uot, max_gt, s, pstream__)), 
                         "assigning variable infectiousness");
             current_statement_begin__ = 286;
             if (as_bool((primitive_value(pop) && primitive_value(logical_gt(s, nht))))) {
@@ -1297,23 +1297,23 @@ generate_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& oR,
                 current_statement_begin__ = 288;
                 stan::math::assign(exp_adj_Rt, (logical_gt(exp_adj_Rt, 1) ? stan::math::promote_scalar<local_scalar_t__>(1) : stan::math::promote_scalar<local_scalar_t__>(exp_adj_Rt) ));
                 current_statement_begin__ = 289;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()),
-                            ((pop - get_base1(cum_infections, s, "cum_infections", 1)) * (1 - exp_adj_Rt)),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), 
+                            ((pop - get_base1(cum_infections, s, "cum_infections", 1)) * (1 - exp_adj_Rt)), 
                             "assigning variable infections");
             } else {
                 current_statement_begin__ = 291;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()),
-                            (stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), "infections") + (get_base1(R, s, "R", 1) * get_base1(infectiousness, s, "infectiousness", 1))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), 
+                            (stan::model::rvalue(infections, stan::model::cons_list(stan::model::index_uni((s + uot)), stan::model::nil_index_list()), "infections") + (get_base1(R, s, "R", 1) * get_base1(infectiousness, s, "infectiousness", 1))), 
                             "assigning variable infections");
             }
             current_statement_begin__ = 293;
             if (as_bool((primitive_value(pop) && primitive_value(logical_lt(s, ot))))) {
                 current_statement_begin__ = 294;
-                stan::model::assign(cum_infections,
-                            stan::model::cons_list(stan::model::index_uni((s + 1)), stan::model::nil_index_list()),
-                            (get_base1(cum_infections, s, "cum_infections", 1) + get_base1(infections, (s + uot), "infections", 1)),
+                stan::model::assign(cum_infections, 
+                            stan::model::cons_list(stan::model::index_uni((s + 1)), stan::model::nil_index_list()), 
+                            (get_base1(cum_infections, s, "cum_infections", 1) + get_base1(infections, (s + uot), "infections", 1)), 
                             "assigning variable cum_infections");
             }
         }
@@ -1385,16 +1385,16 @@ deconvolve_infections(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& shifted_case
                 stan::math::assign(infections, add(infections, exp_noise));
             } else if (as_bool(logical_eq(prior, 2))) {
                 current_statement_begin__ = 311;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                            (get_base1(infections, 1, "infections", 1) + (get_base1(shifted_cases, 1, "shifted_cases", 1) * get_base1(exp_noise, 1, "exp_noise", 1))),
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                            (get_base1(infections, 1, "infections", 1) + (get_base1(shifted_cases, 1, "shifted_cases", 1) * get_base1(exp_noise, 1, "exp_noise", 1))), 
                             "assigning variable infections");
                 current_statement_begin__ = 312;
                 for (int i = 2; i <= t; ++i) {
                     current_statement_begin__ = 313;
-                    stan::model::assign(infections,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(infections, (i - 1), "infections", 1) * get_base1(exp_noise, i, "exp_noise", 1)),
+                    stan::model::assign(infections, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(infections, (i - 1), "infections", 1) * get_base1(exp_noise, i, "exp_noise", 1)), 
                                 "assigning variable infections");
                 }
             }
@@ -1495,9 +1495,9 @@ day_of_week_effect(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
         current_statement_begin__ = 334;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 336;
-            stan::model::assign(scaled_reports,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)),
+            stan::model::assign(scaled_reports, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)), 
                         "assigning variable scaled_reports");
         }
         current_statement_begin__ = 338;
@@ -1586,17 +1586,17 @@ truncation_cmf(const T0__& trunc_mean,
         current_statement_begin__ = 352;
         for (int i = 1; i <= trunc_max; ++i) {
             current_statement_begin__ = 353;
-            stan::model::assign(trunc_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (i - 1),
+            stan::model::assign(trunc_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (i - 1), 
                         "assigning variable trunc_indexes");
         }
         current_statement_begin__ = 355;
         stan::math::assign(cmf, discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max, pstream__));
         current_statement_begin__ = 356;
-        stan::model::assign(cmf,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (get_base1(cmf, 1, "cmf", 1) + 1e-8),
+        stan::model::assign(cmf, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (get_base1(cmf, 1, "cmf", 1) + 1e-8), 
                     "assigning variable cmf");
         current_statement_begin__ = 357;
         stan::math::assign(cmf, cumulative_sum(cmf));
@@ -1679,15 +1679,15 @@ truncate(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 375;
             if (as_bool(reconstruct)) {
                 current_statement_begin__ = 376;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             } else {
                 current_statement_begin__ = 378;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             }
             }
@@ -1861,18 +1861,18 @@ report_log_lik(const std::vector<int>& cases,
                 current_statement_begin__ = 422;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 423;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                                 "assigning variable log_lik");
                 }
             } else {
                 current_statement_begin__ = 426;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 427;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight), 
                                 "assigning variable log_lik");
                 }
             }
@@ -1881,9 +1881,9 @@ report_log_lik(const std::vector<int>& cases,
             current_statement_begin__ = 431;
             for (int i = 1; i <= t; ++i) {
                 current_statement_begin__ = 432;
-                stan::model::assign(log_lik,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                stan::model::assign(log_lik, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                             "assigning variable log_lik");
             }
         }
@@ -1944,15 +1944,15 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 446;
                 if (as_bool(logical_gt(sqrt_phi, 1e4))) {
                     current_statement_begin__ = 447;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                                 "assigning variable sampled_reports");
                 } else {
                     current_statement_begin__ = 449;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__), 
                                 "assigning variable sampled_reports");
                 }
             }
@@ -1960,9 +1960,9 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 453;
             for (int s = 1; s <= t; ++s) {
                 current_statement_begin__ = 454;
-                stan::model::assign(sampled_reports,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                stan::model::assign(sampled_reports, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                             "assigning variable sampled_reports");
             }
         }
@@ -2039,9 +2039,9 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
         current_statement_begin__ = 473;
         for (int i = 1; i <= max_gt; ++i) {
             current_statement_begin__ = 474;
-            stan::model::assign(gt_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((max_gt - i) + 1),
+            stan::model::assign(gt_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((max_gt - i) + 1), 
                         "assigning variable gt_indexes");
         }
         current_statement_begin__ = 476;
@@ -2049,14 +2049,14 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
         current_statement_begin__ = 478;
         for (int s = 1; s <= ot; ++s) {
             current_statement_begin__ = 479;
-            stan::model::assign(infectiousness,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, seeding_time, max_gt, s, pstream__)),
+            stan::model::assign(infectiousness, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(infectiousness, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "infectiousness") + update_infectiousness(infections, gt_pmf, seeding_time, max_gt, s, pstream__)), 
                         "assigning variable infectiousness");
             current_statement_begin__ = 480;
-            stan::model::assign(R,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(infections, (s + seeding_time), "infections", 1) / get_base1(infectiousness, s, "infectiousness", 1)),
+            stan::model::assign(R, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(infections, (s + seeding_time), "infections", 1) / get_base1(infectiousness, s, "infectiousness", 1)), 
                         "assigning variable R");
         }
         current_statement_begin__ = 482;
@@ -2071,24 +2071,24 @@ calculate_Rt(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 stan::math::fill(window, DUMMY_VAR__);
                 stan::math::assign(window,0);
                 current_statement_begin__ = 485;
-                stan::model::assign(sR,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            0,
+                stan::model::assign(sR, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            0, 
                             "assigning variable sR");
                 current_statement_begin__ = 486;
                 for (int i = std::max(1, (s - smooth)); i <= std::min(ot, (s + smooth)); ++i) {
                     current_statement_begin__ = 487;
-                    stan::model::assign(sR,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                (stan::model::rvalue(sR, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "sR") + get_base1(R, i, "R", 1)),
+                    stan::model::assign(sR, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(sR, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "sR") + get_base1(R, i, "R", 1)), 
                                 "assigning variable sR");
                     current_statement_begin__ = 488;
                     stan::math::assign(window, (window + 1));
                 }
                 current_statement_begin__ = 490;
-                stan::model::assign(sR,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            (get_base1(sR, s, "sR", 1) / window),
+                stan::model::assign(sR, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            (get_base1(sR, s, "sR", 1) / window), 
                             "assigning variable sR");
                 }
             }
@@ -2150,9 +2150,9 @@ R_to_growth(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& R,
         current_statement_begin__ = 502;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 503;
-            stan::model::assign(r,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        ((pow(get_base1(R, s, "R", 1), k) - 1) / (k * gt_mean)),
+            stan::model::assign(r, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        ((pow(get_base1(R, s, "R", 1), k) - 1) / (k * gt_mean)), 
                         "assigning variable r");
         }
         current_statement_begin__ = 505;
@@ -2171,6 +2171,58 @@ struct R_to_growth_functor__ {
                 const T1__& gt_mean,
                 const T2__& gt_sd, std::ostream* pstream__) const {
         return R_to_growth(R, gt_mean, gt_sd, pstream__);
+    }
+};
+template <typename T0__>
+std::vector<typename boost::math::tools::promote_args<T0__>::type>
+calculate_growth(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
+                     const int& seeding_time, std::ostream* pstream__) {
+    typedef typename boost::math::tools::promote_args<T0__>::type local_scalar_t__;
+    typedef local_scalar_t__ fun_return_scalar_t__;
+    const static bool propto__ = true;
+    (void) propto__;
+        local_scalar_t__ DUMMY_VAR__(std::numeric_limits<double>::quiet_NaN());
+        (void) DUMMY_VAR__;  // suppress unused var warning
+    int current_statement_begin__ = -1;
+    try {
+        {
+        current_statement_begin__ = 509;
+        int t(0);
+        (void) t;  // dummy to suppress unused var warning
+        stan::math::fill(t, std::numeric_limits<int>::min());
+        stan::math::assign(t,num_elements(infections));
+        current_statement_begin__ = 510;
+        int ot(0);
+        (void) ot;  // dummy to suppress unused var warning
+        stan::math::fill(ot, std::numeric_limits<int>::min());
+        stan::math::assign(ot,(t - seeding_time));
+        current_statement_begin__ = 511;
+        validate_non_negative_index("log_inf", "t", t);
+        Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> log_inf(t);
+        stan::math::initialize(log_inf, DUMMY_VAR__);
+        stan::math::fill(log_inf, DUMMY_VAR__);
+        stan::math::assign(log_inf,stan::math::log(infections));
+        current_statement_begin__ = 512;
+        validate_non_negative_index("growth", "ot", ot);
+        Eigen::Matrix<local_scalar_t__, Eigen::Dynamic, 1> growth(ot);
+        stan::math::initialize(growth, DUMMY_VAR__);
+        stan::math::fill(growth, DUMMY_VAR__);
+        stan::math::assign(growth,subtract(stan::model::rvalue(log_inf, stan::model::cons_list(stan::model::index_min_max((seeding_time + 1), t), stan::model::nil_index_list()), "log_inf"), stan::model::rvalue(log_inf, stan::model::cons_list(stan::model::index_min_max(seeding_time, (t - 1)), stan::model::nil_index_list()), "log_inf")));
+        current_statement_begin__ = 513;
+        return stan::math::promote_scalar<fun_return_scalar_t__>(to_array_1d(growth));
+        }
+    } catch (const std::exception& e) {
+        stan::lang::rethrow_located(e, current_statement_begin__, prog_reader__());
+        // Next line prevents compiler griping about no return
+        throw std::runtime_error("*** IF YOU SEE THIS, PLEASE REPORT A BUG ***");
+    }
+}
+struct calculate_growth_functor__ {
+    template <typename T0__>
+        std::vector<typename boost::math::tools::promote_args<T0__>::type>
+    operator()(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
+                     const int& seeding_time, std::ostream* pstream__) const {
+        return calculate_growth(infections, seeding_time, pstream__);
     }
 };
 #include <stan_meta_header.hpp>
@@ -2229,31 +2281,31 @@ public:
         (void) DUMMY_VAR__;  // suppress unused var warning
         try {
             // initialize data block variables from context__
-            current_statement_begin__ = 511;
+            current_statement_begin__ = 519;
             context__.validate_dims("data initialization", "n", "int", context__.to_vec());
             n = int(0);
             vals_i__ = context__.vals_i("n");
             pos__ = 0;
             n = vals_i__[pos__++];
-            current_statement_begin__ = 512;
+            current_statement_begin__ = 520;
             context__.validate_dims("data initialization", "t", "int", context__.to_vec());
             t = int(0);
             vals_i__ = context__.vals_i("t");
             pos__ = 0;
             t = vals_i__[pos__++];
-            current_statement_begin__ = 513;
+            current_statement_begin__ = 521;
             context__.validate_dims("data initialization", "seeding_time", "int", context__.to_vec());
             seeding_time = int(0);
             vals_i__ = context__.vals_i("seeding_time");
             pos__ = 0;
             seeding_time = vals_i__[pos__++];
-            current_statement_begin__ = 514;
+            current_statement_begin__ = 522;
             context__.validate_dims("data initialization", "future_time", "int", context__.to_vec());
             future_time = int(0);
             vals_i__ = context__.vals_i("future_time");
             pos__ = 0;
             future_time = vals_i__[pos__++];
-            current_statement_begin__ = 516;
+            current_statement_begin__ = 524;
             validate_non_negative_index("initial_infections", "(seeding_time ? n : 0 )", (seeding_time ? n : 0 ));
             validate_non_negative_index("initial_infections", "1", 1);
             context__.validate_dims("data initialization", "initial_infections", "double", context__.to_vec((seeding_time ? n : 0 ),1));
@@ -2267,7 +2319,7 @@ public:
                     initial_infections[k_0__][k_1__] = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 517;
+            current_statement_begin__ = 525;
             validate_non_negative_index("initial_growth", "(logical_gt(seeding_time, 1) ? n : 0 )", (logical_gt(seeding_time, 1) ? n : 0 ));
             validate_non_negative_index("initial_growth", "1", 1);
             context__.validate_dims("data initialization", "initial_growth", "double", context__.to_vec((logical_gt(seeding_time, 1) ? n : 0 ),1));
@@ -2281,7 +2333,7 @@ public:
                     initial_growth[k_0__][k_1__] = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 518;
+            current_statement_begin__ = 526;
             validate_non_negative_index("gt_mean", "n", n);
             validate_non_negative_index("gt_mean", "1", 1);
             context__.validate_dims("data initialization", "gt_mean", "double", context__.to_vec(n,1));
@@ -2302,7 +2354,7 @@ public:
                     check_greater_or_equal(function__, "gt_mean[i_0__][i_1__]", gt_mean[i_0__][i_1__], 0);
                 }
             }
-            current_statement_begin__ = 519;
+            current_statement_begin__ = 527;
             validate_non_negative_index("gt_sd", "n", n);
             validate_non_negative_index("gt_sd", "1", 1);
             context__.validate_dims("data initialization", "gt_sd", "double", context__.to_vec(n,1));
@@ -2323,13 +2375,13 @@ public:
                     check_greater_or_equal(function__, "gt_sd[i_0__][i_1__]", gt_sd[i_0__][i_1__], 0);
                 }
             }
-            current_statement_begin__ = 520;
+            current_statement_begin__ = 528;
             context__.validate_dims("data initialization", "max_gt", "int", context__.to_vec());
             max_gt = int(0);
             vals_i__ = context__.vals_i("max_gt");
             pos__ = 0;
             max_gt = vals_i__[pos__++];
-            current_statement_begin__ = 521;
+            current_statement_begin__ = 529;
             validate_non_negative_index("R", "n", n);
             validate_non_negative_index("R", "(t - seeding_time)", (t - seeding_time));
             context__.validate_dims("data initialization", "R", "matrix_d", context__.to_vec(n,(t - seeding_time)));
@@ -2343,19 +2395,19 @@ public:
                     R(j_1__, j_2__) = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 522;
+            current_statement_begin__ = 530;
             context__.validate_dims("data initialization", "pop", "int", context__.to_vec());
             pop = int(0);
             vals_i__ = context__.vals_i("pop");
             pos__ = 0;
             pop = vals_i__[pos__++];
-            current_statement_begin__ = 524;
+            current_statement_begin__ = 532;
             context__.validate_dims("data initialization", "delays", "int", context__.to_vec());
             delays = int(0);
             vals_i__ = context__.vals_i("delays");
             pos__ = 0;
             delays = vals_i__[pos__++];
-            current_statement_begin__ = 525;
+            current_statement_begin__ = 533;
             validate_non_negative_index("delay_mean", "n", n);
             validate_non_negative_index("delay_mean", "delays", delays);
             context__.validate_dims("data initialization", "delay_mean", "double", context__.to_vec(n,delays));
@@ -2369,7 +2421,7 @@ public:
                     delay_mean[k_0__][k_1__] = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 526;
+            current_statement_begin__ = 534;
             validate_non_negative_index("delay_sd", "n", n);
             validate_non_negative_index("delay_sd", "delays", delays);
             context__.validate_dims("data initialization", "delay_sd", "double", context__.to_vec(n,delays));
@@ -2383,7 +2435,7 @@ public:
                     delay_sd[k_0__][k_1__] = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 527;
+            current_statement_begin__ = 535;
             validate_non_negative_index("max_delay", "delays", delays);
             context__.validate_dims("data initialization", "max_delay", "int", context__.to_vec(delays));
             max_delay = std::vector<int>(delays, int(0));
@@ -2393,7 +2445,7 @@ public:
             for (size_t k_0__ = 0; k_0__ < max_delay_k_0_max__; ++k_0__) {
                 max_delay[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 529;
+            current_statement_begin__ = 537;
             validate_non_negative_index("day_of_week", "(t - seeding_time)", (t - seeding_time));
             context__.validate_dims("data initialization", "day_of_week", "int", context__.to_vec((t - seeding_time)));
             day_of_week = std::vector<int>((t - seeding_time), int(0));
@@ -2403,13 +2455,13 @@ public:
             for (size_t k_0__ = 0; k_0__ < day_of_week_k_0_max__; ++k_0__) {
                 day_of_week[k_0__] = vals_i__[pos__++];
             }
-            current_statement_begin__ = 530;
+            current_statement_begin__ = 538;
             context__.validate_dims("data initialization", "week_effect", "int", context__.to_vec());
             week_effect = int(0);
             vals_i__ = context__.vals_i("week_effect");
             pos__ = 0;
             week_effect = vals_i__[pos__++];
-            current_statement_begin__ = 531;
+            current_statement_begin__ = 539;
             validate_non_negative_index("day_of_week_simplex", "n", n);
             validate_non_negative_index("day_of_week_simplex", "(week_effect ? 7 : 1 )", (week_effect ? 7 : 1 ));
             context__.validate_dims("data initialization", "day_of_week_simplex", "double", context__.to_vec(n,(week_effect ? 7 : 1 )));
@@ -2430,13 +2482,13 @@ public:
                     check_greater_or_equal(function__, "day_of_week_simplex[i_0__][i_1__]", day_of_week_simplex[i_0__][i_1__], 0);
                 }
             }
-            current_statement_begin__ = 532;
+            current_statement_begin__ = 540;
             context__.validate_dims("data initialization", "obs_scale", "int", context__.to_vec());
             obs_scale = int(0);
             vals_i__ = context__.vals_i("obs_scale");
             pos__ = 0;
             obs_scale = vals_i__[pos__++];
-            current_statement_begin__ = 533;
+            current_statement_begin__ = 541;
             validate_non_negative_index("frac_obs", "n", n);
             validate_non_negative_index("frac_obs", "obs_scale", obs_scale);
             context__.validate_dims("data initialization", "frac_obs", "double", context__.to_vec(n,obs_scale));
@@ -2450,13 +2502,13 @@ public:
                     frac_obs[k_0__][k_1__] = vals_r__[pos__++];
                 }
             }
-            current_statement_begin__ = 534;
+            current_statement_begin__ = 542;
             context__.validate_dims("data initialization", "model_type", "int", context__.to_vec());
             model_type = int(0);
             vals_i__ = context__.vals_i("model_type");
             pos__ = 0;
             model_type = vals_i__[pos__++];
-            current_statement_begin__ = 535;
+            current_statement_begin__ = 543;
             validate_non_negative_index("rep_phi", "n", n);
             validate_non_negative_index("rep_phi", "model_type", model_type);
             context__.validate_dims("data initialization", "rep_phi", "double", context__.to_vec(n,model_type));
@@ -2568,7 +2620,7 @@ public:
         dimss__.push_back(dims__);
         dims__.resize(0);
         dims__.push_back(n);
-        dims__.push_back((t - seeding_time));
+        dims__.push_back(((t - seeding_time) - 1));
         dimss__.push_back(dims__);
     }
     template <typename RNG>
@@ -2595,71 +2647,71 @@ public:
             if (!include_gqs__ && !include_tparams__) return;
             if (!include_gqs__) return;
             // declare and define generated quantities
-            current_statement_begin__ = 540;
+            current_statement_begin__ = 548;
             validate_non_negative_index("infections", "n", n);
             validate_non_negative_index("infections", "t", t);
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> infections(n, t);
             stan::math::initialize(infections, DUMMY_VAR__);
             stan::math::fill(infections, DUMMY_VAR__);
-            current_statement_begin__ = 541;
+            current_statement_begin__ = 549;
             validate_non_negative_index("reports", "n", n);
             validate_non_negative_index("reports", "(t - seeding_time)", (t - seeding_time));
             Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic> reports(n, (t - seeding_time));
             stan::math::initialize(reports, DUMMY_VAR__);
             stan::math::fill(reports, DUMMY_VAR__);
-            current_statement_begin__ = 542;
+            current_statement_begin__ = 550;
             validate_non_negative_index("imputed_reports", "n", n);
             validate_non_negative_index("imputed_reports", "(t - seeding_time)", (t - seeding_time));
             std::vector<std::vector<int> > imputed_reports(n, std::vector<int>((t - seeding_time), int(0)));
             stan::math::fill(imputed_reports, std::numeric_limits<int>::min());
-            current_statement_begin__ = 543;
+            current_statement_begin__ = 551;
             validate_non_negative_index("r", "n", n);
-            validate_non_negative_index("r", "(t - seeding_time)", (t - seeding_time));
-            std::vector<std::vector<double> > r(n, std::vector<double>((t - seeding_time), double(0)));
+            validate_non_negative_index("r", "((t - seeding_time) - 1)", ((t - seeding_time) - 1));
+            std::vector<std::vector<double> > r(n, std::vector<double>(((t - seeding_time) - 1), double(0)));
             stan::math::initialize(r, DUMMY_VAR__);
             stan::math::fill(r, DUMMY_VAR__);
             // generated quantities statements
-            current_statement_begin__ = 544;
+            current_statement_begin__ = 552;
             for (int i = 1; i <= n; ++i) {
-                current_statement_begin__ = 546;
-                stan::model::assign(infections,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            to_row_vector(generate_infections(to_vector(get_base1(R, i, "R", 1)), seeding_time, get_base1(gt_mean, i, "gt_mean", 1), get_base1(gt_sd, i, "gt_sd", 1), max_gt, get_base1(initial_infections, i, "initial_infections", 1), get_base1(initial_growth, i, "initial_growth", 1), pop, future_time, pstream__)),
-                            "assigning variable infections");
-                current_statement_begin__ = 551;
-                stan::model::assign(reports,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            to_row_vector(convolve_to_report(to_vector(get_base1(infections, i, "infections", 1)), get_base1(delay_mean, i, "delay_mean", 1), get_base1(delay_sd, i, "delay_sd", 1), max_delay, seeding_time, pstream__)),
-                            "assigning variable reports");
                 current_statement_begin__ = 554;
-                if (as_bool(week_effect)) {
-                    current_statement_begin__ = 555;
-                    stan::model::assign(reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                to_row_vector(day_of_week_effect(to_vector(get_base1(reports, i, "reports", 1)), day_of_week, to_vector(get_base1(day_of_week_simplex, i, "day_of_week_simplex", 1)), pstream__)),
-                                "assigning variable reports");
-                }
+                stan::model::assign(infections, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            to_row_vector(generate_infections(to_vector(get_base1(R, i, "R", 1)), seeding_time, get_base1(gt_mean, i, "gt_mean", 1), get_base1(gt_sd, i, "gt_sd", 1), max_gt, get_base1(initial_infections, i, "initial_infections", 1), get_base1(initial_growth, i, "initial_growth", 1), pop, future_time, pstream__)), 
+                            "assigning variable infections");
                 current_statement_begin__ = 559;
-                if (as_bool(obs_scale)) {
-                    current_statement_begin__ = 560;
-                    stan::model::assign(reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                to_row_vector(scale_obs(to_vector(get_base1(reports, i, "reports", 1)), get_base1(get_base1(frac_obs, i, "frac_obs", 1), 1, "frac_obs", 2), pstream__)),
+                stan::model::assign(reports, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            to_row_vector(convolve_to_report(to_vector(get_base1(infections, i, "infections", 1)), get_base1(delay_mean, i, "delay_mean", 1), get_base1(delay_sd, i, "delay_sd", 1), max_delay, seeding_time, pstream__)), 
+                            "assigning variable reports");
+                current_statement_begin__ = 562;
+                if (as_bool(week_effect)) {
+                    current_statement_begin__ = 563;
+                    stan::model::assign(reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                to_row_vector(day_of_week_effect(to_vector(get_base1(reports, i, "reports", 1)), day_of_week, to_vector(get_base1(day_of_week_simplex, i, "day_of_week_simplex", 1)), pstream__)), 
                                 "assigning variable reports");
                 }
-                current_statement_begin__ = 563;
-                stan::model::assign(imputed_reports,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            report_rng(to_vector(get_base1(reports, i, "reports", 1)), get_base1(rep_phi, i, "rep_phi", 1), model_type, base_rng__, pstream__),
+                current_statement_begin__ = 567;
+                if (as_bool(obs_scale)) {
+                    current_statement_begin__ = 568;
+                    stan::model::assign(reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                to_row_vector(scale_obs(to_vector(get_base1(reports, i, "reports", 1)), get_base1(get_base1(frac_obs, i, "frac_obs", 1), 1, "frac_obs", 2), pstream__)), 
+                                "assigning variable reports");
+                }
+                current_statement_begin__ = 571;
+                stan::model::assign(imputed_reports, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            report_rng(to_vector(get_base1(reports, i, "reports", 1)), get_base1(rep_phi, i, "rep_phi", 1), model_type, base_rng__, pstream__), 
                             "assigning variable imputed_reports");
-                current_statement_begin__ = 564;
-                stan::model::assign(r,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            R_to_growth(to_vector(get_base1(R, i, "R", 1)), get_base1(get_base1(gt_mean, i, "gt_mean", 1), 1, "gt_mean", 2), get_base1(get_base1(gt_sd, i, "gt_sd", 1), 1, "gt_sd", 2), pstream__),
+                current_statement_begin__ = 572;
+                stan::model::assign(r, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            calculate_growth(to_vector(get_base1(infections, i, "infections", 1)), (seeding_time + 1), pstream__), 
                             "assigning variable r");
             }
             // validate, write generated quantities
-            current_statement_begin__ = 540;
+            current_statement_begin__ = 548;
             size_t infections_j_2_max__ = t;
             size_t infections_j_1_max__ = n;
             for (size_t j_2__ = 0; j_2__ < infections_j_2_max__; ++j_2__) {
@@ -2667,7 +2719,7 @@ public:
                     vars__.push_back(infections(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 541;
+            current_statement_begin__ = 549;
             size_t reports_j_2_max__ = (t - seeding_time);
             size_t reports_j_1_max__ = n;
             for (size_t j_2__ = 0; j_2__ < reports_j_2_max__; ++j_2__) {
@@ -2675,7 +2727,7 @@ public:
                     vars__.push_back(reports(j_1__, j_2__));
                 }
             }
-            current_statement_begin__ = 542;
+            current_statement_begin__ = 550;
             size_t imputed_reports_k_0_max__ = n;
             size_t imputed_reports_k_1_max__ = (t - seeding_time);
             for (size_t k_1__ = 0; k_1__ < imputed_reports_k_1_max__; ++k_1__) {
@@ -2683,9 +2735,9 @@ public:
                     vars__.push_back(imputed_reports[k_0__][k_1__]);
                 }
             }
-            current_statement_begin__ = 543;
+            current_statement_begin__ = 551;
             size_t r_k_0_max__ = n;
-            size_t r_k_1_max__ = (t - seeding_time);
+            size_t r_k_1_max__ = ((t - seeding_time) - 1);
             for (size_t k_1__ = 0; k_1__ < r_k_1_max__; ++k_1__) {
                 for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
                     vars__.push_back(r[k_0__][k_1__]);
@@ -2753,7 +2805,7 @@ public:
             }
         }
         size_t r_k_0_max__ = n;
-        size_t r_k_1_max__ = (t - seeding_time);
+        size_t r_k_1_max__ = ((t - seeding_time) - 1);
         for (size_t k_1__ = 0; k_1__ < r_k_1_max__; ++k_1__) {
             for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
                 param_name_stream__.str(std::string());
@@ -2798,7 +2850,7 @@ public:
             }
         }
         size_t r_k_0_max__ = n;
-        size_t r_k_1_max__ = (t - seeding_time);
+        size_t r_k_1_max__ = ((t - seeding_time) - 1);
         for (size_t k_1__ = 0; k_1__ < r_k_1_max__; ++k_1__) {
             for (size_t k_0__ = 0; k_0__ < r_k_0_max__; ++k_0__) {
                 param_name_stream__.str(std::string());

--- a/src/stanExports_simulate_secondary.h
+++ b/src/stanExports_simulate_secondary.h
@@ -143,9 +143,9 @@ discretised_gamma_pmf(const std::vector<int>& y,
         current_statement_begin__ = 21;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 22;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((gamma_cdf((get_base1(y, i, "y", 1) + 1), alpha, beta) - gamma_cdf(get_base1(y, i, "y", 1), alpha, beta)) / trunc_pmf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 25;
@@ -249,9 +249,9 @@ discretised_lognormal_pmf(const std::vector<int>& y,
         current_statement_begin__ = 41;
         for (int i = 1; i <= n; ++i) {
             current_statement_begin__ = 42;
-            stan::model::assign(pmf,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf),
+            stan::model::assign(pmf, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        ((normal_cdf(get_base1(upper_y, i, "upper_y", 1), 0.0, 1.0) - normal_cdf(get_base1(lower_y, i, "lower_y", 1), 0.0, 1.0)) / trunc_cdf), 
                         "assigning variable pmf");
         }
         current_statement_begin__ = 45;
@@ -294,9 +294,9 @@ reverse_mf(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& pmf,
         current_statement_begin__ = 51;
         for (int d = 1; d <= max_pmf; ++d) {
             current_statement_begin__ = 52;
-            stan::model::assign(rev_pmf,
-                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()),
-                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1),
+            stan::model::assign(rev_pmf, 
+                        stan::model::cons_list(stan::model::index_uni(d), stan::model::nil_index_list()), 
+                        get_base1(pmf, ((max_pmf - d) + 1), "pmf", 1), 
                         "assigning variable rev_pmf");
         }
         current_statement_begin__ = 54;
@@ -348,9 +348,9 @@ convolve(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& cases,
         current_statement_begin__ = 61;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 62;
-            stan::model::assign(conv_cases,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))),
+            stan::model::assign(conv_cases, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (stan::model::rvalue(conv_cases, stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), "conv_cases") + dot_product(stan::model::rvalue(cases, stan::model::cons_list(stan::model::index_min_max(std::max(1, ((s - max_pmf) + 1)), s), stan::model::nil_index_list()), "cases"), tail(rev_pmf, std::min(max_pmf, s)))), 
                         "assigning variable conv_cases");
         }
         current_statement_begin__ = 65;
@@ -425,9 +425,9 @@ convolve_to_report(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& infections,
                 current_statement_begin__ = 83;
                 for (int i = 1; i <= get_base1(max_delay, s, "max_delay", 1); ++i) {
                     current_statement_begin__ = 84;
-                    stan::model::assign(delay_indexes,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (get_base1(max_delay, s, "max_delay", 1) - i),
+                    stan::model::assign(delay_indexes, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (get_base1(max_delay, s, "max_delay", 1) - i), 
                                 "assigning variable delay_indexes");
                 }
                 current_statement_begin__ = 86;
@@ -548,9 +548,9 @@ day_of_week_effect(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
         current_statement_begin__ = 113;
         for (int s = 1; s <= t; ++s) {
             current_statement_begin__ = 115;
-            stan::model::assign(scaled_reports,
-                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)),
+            stan::model::assign(scaled_reports, 
+                        stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                        (get_base1(reports, s, "reports", 1) * get_base1(scaled_effect, get_base1(day_of_week, s, "day_of_week", 1), "scaled_effect", 1)), 
                         "assigning variable scaled_reports");
         }
         current_statement_begin__ = 117;
@@ -639,17 +639,17 @@ truncation_cmf(const T0__& trunc_mean,
         current_statement_begin__ = 131;
         for (int i = 1; i <= trunc_max; ++i) {
             current_statement_begin__ = 132;
-            stan::model::assign(trunc_indexes,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (i - 1),
+            stan::model::assign(trunc_indexes, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (i - 1), 
                         "assigning variable trunc_indexes");
         }
         current_statement_begin__ = 134;
         stan::math::assign(cmf, discretised_lognormal_pmf(trunc_indexes, trunc_mean, trunc_sd, trunc_max, pstream__));
         current_statement_begin__ = 135;
-        stan::model::assign(cmf,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (get_base1(cmf, 1, "cmf", 1) + 1e-8),
+        stan::model::assign(cmf, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (get_base1(cmf, 1, "cmf", 1) + 1e-8), 
                     "assigning variable cmf");
         current_statement_begin__ = 136;
         stan::math::assign(cmf, cumulative_sum(cmf));
@@ -732,15 +732,15 @@ truncate(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 154;
             if (as_bool(reconstruct)) {
                 current_statement_begin__ = 155;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_divide(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             } else {
                 current_statement_begin__ = 157;
-                stan::model::assign(trunc_reports,
-                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()),
-                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)),
+                stan::model::assign(trunc_reports, 
+                            stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), 
+                            stan::model::deep_copy(elt_multiply(stan::model::rvalue(trunc_reports, stan::model::cons_list(stan::model::index_min_max(first_t, t), stan::model::nil_index_list()), "trunc_reports"), cmf)), 
                             "assigning variable trunc_reports");
             }
             }
@@ -914,18 +914,18 @@ report_log_lik(const std::vector<int>& cases,
                 current_statement_begin__ = 201;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 202;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                                 "assigning variable log_lik");
                 }
             } else {
                 current_statement_begin__ = 205;
                 for (int i = 1; i <= t; ++i) {
                     current_statement_begin__ = 206;
-                    stan::model::assign(log_lik,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight),
+                    stan::model::assign(log_lik, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (neg_binomial_2_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1), sqrt_phi) * weight), 
                                 "assigning variable log_lik");
                 }
             }
@@ -934,9 +934,9 @@ report_log_lik(const std::vector<int>& cases,
             current_statement_begin__ = 210;
             for (int i = 1; i <= t; ++i) {
                 current_statement_begin__ = 211;
-                stan::model::assign(log_lik,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight),
+                stan::model::assign(log_lik, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            (poisson_log(get_base1(cases, i, "cases", 1), get_base1(reports, i, "reports", 1)) * weight), 
                             "assigning variable log_lik");
             }
         }
@@ -997,15 +997,15 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 225;
                 if (as_bool(logical_gt(sqrt_phi, 1e4))) {
                     current_statement_begin__ = 226;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                                 "assigning variable sampled_reports");
                 } else {
                     current_statement_begin__ = 228;
-                    stan::model::assign(sampled_reports,
-                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__),
+                    stan::model::assign(sampled_reports, 
+                                stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                                neg_binomial_2_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), sqrt_phi, base_rng__), 
                                 "assigning variable sampled_reports");
                 }
             }
@@ -1013,9 +1013,9 @@ report_rng(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
             current_statement_begin__ = 232;
             for (int s = 1; s <= t; ++s) {
                 current_statement_begin__ = 233;
-                stan::model::assign(sampled_reports,
-                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()),
-                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__),
+                stan::model::assign(sampled_reports, 
+                            stan::model::cons_list(stan::model::index_uni(s), stan::model::nil_index_list()), 
+                            poisson_rng((logical_gt(get_base1(reports, s, "reports", 1), 1e8) ? 1e8 : get_base1(reports, s, "reports", 1) ), base_rng__), 
                             "assigning variable sampled_reports");
             }
         }
@@ -1104,15 +1104,15 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 265;
                 if (as_bool(logical_gt(i, predict))) {
                     current_statement_begin__ = 266;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                get_base1(secondary_reports, (i - 1), "secondary_reports", 1),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                get_base1(secondary_reports, (i - 1), "secondary_reports", 1), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 268;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                get_base1(obs, (i - 1), "obs", 1),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                get_base1(obs, (i - 1), "obs", 1), 
                                 "assigning variable secondary_reports");
                 }
             }
@@ -1121,23 +1121,23 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 273;
                 if (as_bool(primary_hist_additive)) {
                     current_statement_begin__ = 274;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(conv_reports, i, "conv_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(conv_reports, i, "conv_reports", 1)), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 276;
                     if (as_bool(logical_gt(get_base1(conv_reports, i, "conv_reports", 1), get_base1(secondary_reports, i, "secondary_reports", 1)))) {
                         current_statement_begin__ = 277;
-                        stan::model::assign(conv_reports,
-                                    stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                    get_base1(secondary_reports, i, "secondary_reports", 1),
+                        stan::model::assign(conv_reports, 
+                                    stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                    get_base1(secondary_reports, i, "secondary_reports", 1), 
                                     "assigning variable conv_reports");
                     }
                     current_statement_begin__ = 279;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(conv_reports, i, "conv_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(conv_reports, i, "conv_reports", 1)), 
                                 "assigning variable secondary_reports");
                 }
             }
@@ -1146,22 +1146,22 @@ calculate_secondary(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& reports,
                 current_statement_begin__ = 284;
                 if (as_bool(primary_current_additive)) {
                     current_statement_begin__ = 285;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(scaled_reports, i, "scaled_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") + get_base1(scaled_reports, i, "scaled_reports", 1)), 
                                 "assigning variable secondary_reports");
                 } else {
                     current_statement_begin__ = 287;
-                    stan::model::assign(secondary_reports,
-                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(scaled_reports, i, "scaled_reports", 1)),
+                    stan::model::assign(secondary_reports, 
+                                stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                                (stan::model::rvalue(secondary_reports, stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), "secondary_reports") - get_base1(scaled_reports, i, "scaled_reports", 1)), 
                                 "assigning variable secondary_reports");
                 }
             }
             current_statement_begin__ = 290;
-            stan::model::assign(secondary_reports,
-                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                        (logical_lte(get_base1(secondary_reports, i, "secondary_reports", 1), 0) ? stan::math::promote_scalar<local_scalar_t__>(1e-5) : stan::math::promote_scalar<local_scalar_t__>(get_base1(secondary_reports, i, "secondary_reports", 1)) ),
+            stan::model::assign(secondary_reports, 
+                        stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                        (logical_lte(get_base1(secondary_reports, i, "secondary_reports", 1), 0) ? stan::math::promote_scalar<local_scalar_t__>(1e-5) : stan::math::promote_scalar<local_scalar_t__>(get_base1(secondary_reports, i, "secondary_reports", 1)) ), 
                         "assigning variable secondary_reports");
         }
         current_statement_begin__ = 292;
@@ -1589,9 +1589,9 @@ public:
                     stan::math::assign(secondary, day_of_week_effect(secondary, day_of_week, to_vector(get_base1(day_of_week_simplex, i, "day_of_week_simplex", 1)), pstream__));
                 }
                 current_statement_begin__ = 341;
-                stan::model::assign(sim_secondary,
-                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()),
-                            report_rng(tail(secondary, (all_dates ? t : h )), get_base1(rep_phi, i, "rep_phi", 1), model_type, base_rng__, pstream__),
+                stan::model::assign(sim_secondary, 
+                            stan::model::cons_list(stan::model::index_uni(i), stan::model::nil_index_list()), 
+                            report_rng(tail(secondary, (all_dates ? t : h )), get_base1(rep_phi, i, "rep_phi", 1), model_type, base_rng__, pstream__), 
                             "assigning variable sim_secondary");
                 }
             }

--- a/src/stanExports_tune_inv_gamma.h
+++ b/src/stanExports_tune_inv_gamma.h
@@ -77,14 +77,14 @@ tail_delta(const Eigen::Matrix<T0__, Eigen::Dynamic, 1>& y,
         current_statement_begin__ = 12;
         stan::math::assign(beta, (logical_gte(beta, 1e6) ? stan::math::promote_scalar<local_scalar_t__>(1e6) : stan::math::promote_scalar<local_scalar_t__>(beta) ));
         current_statement_begin__ = 13;
-        stan::model::assign(deltas,
-                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()),
-                    (inv_gamma_cdf(get_base1(theta, 1, "theta", 1), alpha, beta) - 0.01),
+        stan::model::assign(deltas, 
+                    stan::model::cons_list(stan::model::index_uni(1), stan::model::nil_index_list()), 
+                    (inv_gamma_cdf(get_base1(theta, 1, "theta", 1), alpha, beta) - 0.01), 
                     "assigning variable deltas");
         current_statement_begin__ = 14;
-        stan::model::assign(deltas,
-                    stan::model::cons_list(stan::model::index_uni(2), stan::model::nil_index_list()),
-                    ((1 - inv_gamma_cdf(get_base1(theta, 2, "theta", 1), alpha, beta)) - 0.01),
+        stan::model::assign(deltas, 
+                    stan::model::cons_list(stan::model::index_uni(2), stan::model::nil_index_list()), 
+                    ((1 - inv_gamma_cdf(get_base1(theta, 2, "theta", 1), alpha, beta)) - 0.01), 
                     "assigning variable deltas");
         current_statement_begin__ = 15;
         return stan::math::promote_scalar<fun_return_scalar_t__>(deltas);

--- a/tests/testthat/test-stan-generated_quantities.R
+++ b/tests/testthat/test-stan-generated_quantities.R
@@ -1,0 +1,16 @@
+context("estimate_infections")
+if (!testthat:::on_cran()) {
+  files <- c("pmfs.stan", "infections.stan", "generated_quantities.stan")
+  suppressMessages(expose_stan_fns(files, target_dir = "inst/stan/functions"))# system.file("stan/functions", package = "EpiNow2")))
+}
+
+
+test_that("calculate_growth works as expected", {
+  skip_on_cran()
+  expect_equal(calculate_growth(rep(1, 5), 1), rep(0, 4))
+  expect_equal(round(calculate_growth(1:5, 2), 2), c(0.41, 0.29, 0.22))
+  expect_equal(round(calculate_growth(exp(0.4*1:5), 2), 2), rep(0.4, 3))
+  expect_error(calculate_growth(1:5, 6))
+  expect_error(calculate_growth(1:5, 0))
+})
+

--- a/tests/testthat/test-stan-generated_quantities.R
+++ b/tests/testthat/test-stan-generated_quantities.R
@@ -1,7 +1,7 @@
 context("estimate_infections")
 if (!testthat:::on_cran()) {
   files <- c("pmfs.stan", "infections.stan", "generated_quantities.stan")
-  suppressMessages(expose_stan_fns(files, target_dir = "inst/stan/functions"))# system.file("stan/functions", package = "EpiNow2")))
+  suppressMessages(expose_stan_fns(files, target_dir = system.file("stan/functions", package = "EpiNow2")))
 }
 
 


### PR DESCRIPTION
This updates the output growth rate to be directly calculated from infections (r = log(inf_(t-1)) - log(inf_t)) rather than via the growth rate approximation using Rt. 

1. Adds `calculate_growth` and tests
2. Reduces growth rates output to be number of observations minus 1 (as can't be calculated for the first time step).

Everything looks as I would expect when unit testing and running the examples expect for this slightly odd artefact in the forecast portion that doesn't show up in the Rt or infections plot. 

<img width="857" alt="Screenshot 2020-12-30 at 20 18 25" src="https://user-images.githubusercontent.com/20317649/103379072-54267880-4adc-11eb-903c-2529fc47c96d.png">
