### PR TITLE
GHA: Cleanup workflow

### DIFF
--- a/.github/workflows/check-full.yaml
+++ b/.github/workflows/check-full.yaml
@@ -74,7 +74,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          try(remove.packages("curl"))
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
         shell: Rscript {0}
@@ -151,7 +150,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          try(remove.packages("curl"))
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("lintr")
           remotes::install_cran("sessioninfo")
@@ -216,7 +214,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          try(remove.packages("curl"))
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("sessioninfo")
           remotes::install_cran("styler")


### PR DESCRIPTION
This line isn't needed anymore and should be removed. It causes silent `Error: there is no package called ‘curl’`.