### PR TITLE
Don’t round summaries by default

### DIFF
--- a/R/summarise.R
+++ b/R/summarise.R
@@ -393,9 +393,11 @@ summarise_key_measures <- function(regional_results = NULL,
   } else {
     timeseries <- regional_results
   }
-  summarise_variable <- function(df, dof = 2) {
+  summarise_variable <- function(df, dof = NULL) {
     cols <- setdiff(names(df), c("region", "date", "type", "strat"))
-    df[, (cols) := round(.SD, dof), .SDcols = cols]
+    if (!is.null(dof)) {
+      df[, (cols) := round(.SD, dof), .SDcols = cols]
+    }
     data.table::setorderv(df, cols = c("region", "date", "type", "strat"))
     data.table::setnames(df, "region", type)
     return(df)


### PR DESCRIPTION
I think this is what’s needed to enable us to generate figures on the web site from markdown