### PR TITLE
GP: lengthscale: Use inverse-gamma prior if `ls_sd = 0`

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -485,7 +485,7 @@ create_initial_conditions <- function(data) {
       out$eta <- array(rnorm(data$M, mean = 0, sd = 0.1))
       out$rho <- array(rlnorm(1,
         meanlog = data$ls_meanlog,
-        sdlog = data$ls_sdlog * 0.1
+        sdlog = ifelse(data$ls_sdlog > 0, data$ls_sdlog * 0.1, 0.01)
       ))
       out$rho <- ifelse(out$rho > data$ls_max, data$ls_max - 0.001,
         ifelse(out$rho < data$ls_min, data$ls_min + 0.001,

--- a/R/opts.R
+++ b/R/opts.R
@@ -176,7 +176,8 @@ backcalc_opts <- function(prior = "reports", prior_window = 14, rt_window = 1) {
 #'  process. Custom settings can be supplied which override the defaults.
 #' @param ls_mean Numeric, defaults to 21 days. The mean of the lognormal length scale.
 #' @param ls_sd Numeric, defaults to 7 days. The standard deviation of the log normal length
-#' scale with..
+#' scale. If \code{ls_sd = 0}, inverse-gamma prior on Gaussian process length scale will
+#' be used with recommended parameters \code{inv_gamma(1.499007, 0.057277 * ls_max)}.
 #' @param ls_max Numeric, defaults to 60. The maximum value of the length scale. Updated in
 #' `create_gp_data` to be the length of the input data if this is smaller.
 #' @param ls_min Numeric, defaults to 7. The minimum value of the length scale.

--- a/inst/stan/functions/gaussian_process.stan
+++ b/inst/stan/functions/gaussian_process.stan
@@ -70,7 +70,11 @@ vector update_gp(matrix PHI, int M, real L, real alpha,
 void gaussian_process_lp(real rho, real alpha, vector eta,
                          real ls_meanlog, real ls_sdlog,
                          real ls_min, real ls_max, real alpha_sd) {
-  rho ~ lognormal(ls_meanlog, ls_sdlog) T[ls_min, ls_max];
+  if (ls_sdlog > 0) {
+    rho ~ lognormal(ls_meanlog, ls_sdlog) T[ls_min, ls_max];
+  } else {
+    rho ~ inv_gamma(1.499007, 0.057277 * ls_max) T[ls_min, ls_max];
+  }
   alpha ~ normal(0, alpha_sd);
   eta ~ std_normal();
 }


### PR DESCRIPTION
This is a proposal to address #255. It allows using an inverse-gamma prior on Gaussian process (GP) length-scale parameter while keeping the user interface and the default log-normal prior unchanged. The parameters of the inverse-gamma prior are a function of `ls_max` and have been tested for both short and long simulations where the default prior makes the model unstable. The new prior is **more stable for long simulations** and adaptively change the distribution based on the simulation length (total number of days) without relying on the user inputs or the fixed defaults. **It can be tested by setting `ls_sd = 0` in `gp_opts()`.**

I haven't updated the docs (`roxygen2::roxygenize()`) or reconfigured because I use the development version on Stan.

Here's the summary plot from the example with `gp = gp_opts(ls_sd = 0)`:

![image](https://user-images.githubusercontent.com/7604200/120739846-103b0380-c4c0-11eb-8af0-85df06b6ccf6.png)

@seabbs Feel free to make any changes to this proposal.