### PR TITLE
Switch to script level skipping

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,7 @@ This release is under development and the features outlined below may change bef
 ## Package changes
 
 * Added a `contributing.md` to guide contributors and added `pre-commit` support to check new contributions styling. 
+* Better test skipping thanks to @Bisaloo.
 
 ## Other changes
 

--- a/tests/testthat/test-calc_CrI.R
+++ b/tests/testthat/test-calc_CrI.R
@@ -1,6 +1,3 @@
-context("calc_CrI")
-
-
 samples <- data.frame(value = 1:10, type = "car")
 
 test_that("calc_CrI works as expected with default arguments", {

--- a/tests/testthat/test-calc_CrIs.R
+++ b/tests/testthat/test-calc_CrIs.R
@@ -1,6 +1,3 @@
-context("calc_CrIs")
-
-
 samples <- data.frame(value = 1:10, type = "car")
 
 test_that("calc_CrI works as expected with default arguments", {

--- a/tests/testthat/test-calc_summary_measures.R
+++ b/tests/testthat/test-calc_summary_measures.R
@@ -1,5 +1,3 @@
-context("calc_summary_measures")
-
 samples <- data.frame(value = 1:10, type = "car")
 
 test_that("calc_summary_measures works as expected with default arguments", {

--- a/tests/testthat/test-calc_summary_stats.R
+++ b/tests/testthat/test-calc_summary_stats.R
@@ -1,5 +1,3 @@
-context("calc_summary_stats")
-
 samples <- data.frame(value = 1:10, type = "car")
 
 test_that("calc_summary_stats works as expected with default arguments", {

--- a/tests/testthat/test-create_future-rt.R
+++ b/tests/testthat/test-create_future-rt.R
@@ -1,5 +1,3 @@
-context("create_future_rt")
-
 test_that("create_future_rt works as expected", {
   test_frt <- function(test, true) {
     expect_equal(test$from, true$from)

--- a/tests/testthat/test-create_stan_args.R
+++ b/tests/testthat/test-create_stan_args.R
@@ -1,5 +1,3 @@
-context("create_stan_args")
-
 test_that("create_stan_args returns the expected defaults when the exact method is used", {
   expect_equal(names(create_stan_args()), c(
     "data", "init", "refresh", "object", "method",

--- a/tests/testthat/test-epinow.R
+++ b/tests/testthat/test-epinow.R
@@ -1,26 +1,24 @@
-context("epinow")
+skip_on_cran()
 
-if (!testthat:::on_cran()) {
-  generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani", max_value = 15)
-  incubation_period <- get_incubation_period(disease = "SARS-CoV-2", source = "lauer", max_value = 15)
-  reporting_delay <- list(
+
+generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani", max_value = 15)
+incubation_period <- get_incubation_period(disease = "SARS-CoV-2", source = "lauer", max_value = 15)
+reporting_delay <- list(
     mean = convert_to_logmean(2, 1), mean_sd = 0.1,
     sd = convert_to_logsd(2, 1), sd_sd = 0.1,
     max = 10
   )
 
-  reported_cases <- EpiNow2::example_confirmed[1:30]
+reported_cases <- EpiNow2::example_confirmed[1:30]
 
-  futile.logger::flog.threshold("FATAL")
+futile.logger::flog.threshold("FATAL")
 
-  df_non_zero <- function(df) {
-    expect_true(nrow(df) > 0)
-  }
-  expected_out <- c("estimates", "estimated_reported_cases", "summary", "plots", "timing")
+df_non_zero <- function(df) {
+  expect_true(nrow(df) > 0)
 }
+expected_out <- c("estimates", "estimated_reported_cases", "summary", "plots", "timing")
 
 test_that("epinow produces expected output when run with default settings", {
-  skip_on_cran()
   out <- suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,
@@ -43,7 +41,6 @@ test_that("epinow produces expected output when run with default settings", {
 })
 
 test_that("epinow runs without error when saving to disk", {
-  skip_on_cran()
   expect_null(suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,
@@ -58,7 +55,6 @@ test_that("epinow runs without error when saving to disk", {
 })
 
 test_that("epinow can produce partial output as specified", {
-  skip_on_cran()
   out <- suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,
@@ -82,7 +78,6 @@ test_that("epinow can produce partial output as specified", {
 
 
 test_that("epinow fails as expected when given a short timeout", {
-  skip_on_cran()
   expect_error(suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,
@@ -99,7 +94,6 @@ test_that("epinow fails as expected when given a short timeout", {
 
 
 test_that("epinow fails if given NUTs arguments when using variational inference", {
-  skip_on_cran()
   expect_error(suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,
@@ -115,7 +109,6 @@ test_that("epinow fails if given NUTs arguments when using variational inference
 
 
 test_that("epinow fails if given variational inference arguments when using NUTs", {
-  skip_on_cran()
   expect_error(suppressWarnings(epinow(
     reported_cases = reported_cases,
     generation_time = generation_time,

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -1,6 +1,3 @@
-context("estimate_infections")
-
-
 # Setup for testing -------------------------------------------------------
 
 futile.logger::flog.threshold("FATAL")

--- a/tests/testthat/test-extract_CrIs.R
+++ b/tests/testthat/test-extract_CrIs.R
@@ -1,5 +1,3 @@
-context("extract_CrIs")
-
 test_that("extract_CrIs return the expected credible intervals", {
   samples <- data.frame(value = 1:10, type = "car")
   summarised <- calc_CrIs(samples,

--- a/tests/testthat/test-get_dist.R
+++ b/tests/testthat/test-get_dist.R
@@ -1,6 +1,3 @@
-context("get_dist")
-
-
 test_that("get_dist returns distributional definition data in the format expected by EpiNow2", {
   data <- data.table::data.table(mean = 1, mean_sd = 1, sd = 1, sd_sd = 1, source = "test", disease = "test")
 

--- a/tests/testthat/test-match_output_arguments.R
+++ b/tests/testthat/test-match_output_arguments.R
@@ -1,5 +1,3 @@
-context("match_output_arguments")
-
 test_that("match_output_arguments works as expected", {
   out <- rep(FALSE, 3)
   names(out) <- c("fit", "plots", "samples")

--- a/tests/testthat/test-regional_epinow.R
+++ b/tests/testthat/test-regional_epinow.R
@@ -1,11 +1,11 @@
-context("regional_epinow")
+
+skip_on_cran()
 
 generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani", max_value = 5)
 reporting_delay <- list(
   mean = log(3), mean_sd = 0.1,
   sd = log(2), sd_sd = 0.1, max = 5
 )
-
 
 futile.logger::flog.threshold("FATAL")
 
@@ -21,7 +21,6 @@ df_non_zero <- function(df) {
 }
 
 test_that("regional_epinow produces expected output when run with default settings", {
-  skip_on_cran()
   out <- suppressWarnings(
     regional_epinow(
       reported_cases = cases, generation_time = generation_time,
@@ -51,7 +50,6 @@ test_that("regional_epinow produces expected output when run with default settin
 })
 
 test_that("regional_epinow runs without error when given a very short timeout", {
-  skip_on_cran()
   expect_error(
     regional_epinow(
       reported_cases = cases, generation_time = generation_time,
@@ -82,7 +80,6 @@ test_that("regional_epinow runs without error when given a very short timeout", 
 
 
 test_that("regional_epinow produces expected output when run with region specific settings", {
-  skip_on_cran()
   gp <- opts_list(gp_opts(), cases)
   gp <- update_list(gp, list(realland = NULL))
   rt <- opts_list(rt_opts(), cases, realland = rt_opts(rw = 7))

--- a/tests/testthat/test-regional_runtimes.R
+++ b/tests/testthat/test-regional_runtimes.R
@@ -1,5 +1,3 @@
-context("regional_epinow")
-
 generation_time <- get_generation_time(disease = "SARS-CoV-2", source = "ganyani", max_value = 5)
 reporting_delay <- list(
   mean = log(3), mean_sd = 0.1,

--- a/tests/testthat/test-set_dt_single_thread.R
+++ b/tests/testthat/test-set_dt_single_thread.R
@@ -1,5 +1,3 @@
-context("set_dt_single_thread")
-
 # This function calls set_dt_single_thread within a test function
 # and returns the number of threads used during and after function call
 

--- a/tests/testthat/test-setup_future.R
+++ b/tests/testthat/test-setup_future.R
@@ -1,5 +1,3 @@
-context("setup_future")
-
 reported_cases <- data.frame(region = c("test", "boo"))
 futile.logger::flog.threshold("FATAL")
 

--- a/tests/testthat/test-simulate_infections.R
+++ b/tests/testthat/test-simulate_infections.R
@@ -1,5 +1,4 @@
-context("simulate_infections")
-
+skip_on_cran()
 # Setup for testing -------------------------------------------------------
 futile.logger::flog.threshold("FATAL")
 reported_cases <- EpiNow2::example_confirmed[1:50]
@@ -10,9 +9,8 @@ reporting_delay <- list(
   sd = convert_to_logsd(2, 1), sd_sd = 0.1, max = 10
 )
 
-if (!testthat:::on_cran()) {
-  library(data.table)
-  out <- suppressWarnings(estimate_infections(reported_cases,
+library(data.table)
+out <- suppressWarnings(estimate_infections(reported_cases,
     generation_time = generation_time,
     delays = delay_opts(reporting_delay),
     gp = NULL, rt = rt_opts(rw = 14),
@@ -20,45 +18,39 @@ if (!testthat:::on_cran()) {
       chains = 2, warmup = 100, samples = 100,
       control = list(adapt_delta = 0.9)
     )
-  ))
-}
+))
+
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object", {
-  skip_on_cran()
   sims <- simulate_infections(out)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with an adjusted Rt", {
-  skip_on_cran()
   R <- c(rep(NA_real_, 40), rep(0.5, 17))
   sims <- simulate_infections(out, R)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with a short adjusted Rt", {
-  skip_on_cran()
   R <- c(rep(NA_real_, 40), rep(0.5, 10))
   sims <- simulate_infections(out, R)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with a long adjusted Rt", {
-  skip_on_cran()
   R <- c(rep(NA_real_, 40), rep(1.2, 15), rep(0.8, 15))
   sims <- simulate_infections(out, R)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
 })
 
 test_that("simulate infections fails as expected", {
-  skip_on_cran()
   expect_error(simulate_infections())
   expect_error(simualate_infections(out, R = rep(1, 10)))
   expect_error(simulate_infections(out[-"fit"]))
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with an adjusted Rt in data frame", {
-  skip_on_cran()
   R <- c(rep(NA_real_, 40), rep(0.5, 17))
   R_dt <- data.frame(date = summary(out, type = "parameters", param = "R")$date, value = R)
   sims_dt <- simulate_infections(out, R_dt)
@@ -66,11 +58,9 @@ test_that("simulate_infections works to simulate a passed in estimate_infections
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with samples of Rt in a data frame", {
-  skip_on_cran()
   R_samples <- summary(out, type = "samples", param = "R")
   R_samples <- R_samples[,.(date, sample, value)][sample <= 1000]
   R_samples <- R_samples[date >= "2020-04-01", value := 1.1]
   sims_sample <- simulate_infections(out, R_samples)
   expect_equal(names(sims_sample), c("samples", "summarised", "observations"))
 })
-

--- a/tests/testthat/test-stan-infections.R
+++ b/tests/testthat/test-stan-infections.R
@@ -1,13 +1,10 @@
-context("estimate_infections")
-if (!testthat:::on_cran()) {
-  files <- c("pmfs.stan", "infections.stan")
-  suppressMessages(expose_stan_fns(files, target_dir = system.file("stan/functions", package = "EpiNow2")))
-}
+skip_on_cran()
+files <- c("pmfs.stan", "infections.stan")
+suppressMessages(expose_stan_fns(files, target_dir = system.file("stan/functions", package = "EpiNow2")))
 
 
 # test update_infectiousness
 test_that("update_infectiousness works as expected with default settings", {
-  skip_on_cran()
   expect_equal(
     update_infectiousness(rep(1, 20), rep(0.1, 10), 5, 10, 10),
     1
@@ -22,7 +19,6 @@ test_that("update_infectiousness works as expected with default settings", {
 
 # test generate infections
 test_that("generate_infections works as expected", {
-  skip_on_cran()
   expect_equal(
     round(generate_infections(c(1, rep(1, 9)), 10, 3, 2, 15, log(1000), 0, 0, 0), 0),
     c(rep(1000, 10), 996, rep(997, 3), rep(998, 6))

--- a/tests/testthat/test-stan-rt.R
+++ b/tests/testthat/test-stan-rt.R
@@ -1,32 +1,27 @@
-context("estimate_infections")
-if (!testthat:::on_cran()) {
-  suppressMessages(expose_stan_fns("rt.stan", target_dir = system.file("stan/functions", package = "EpiNow2")))
-}
+skip_on_cran()
+suppressMessages(expose_stan_fns("rt.stan", target_dir = system.file("stan/functions", package = "EpiNow2")))
+
 
 # Test update_Rt
 test_that("update_Rt works to produce multiple Rt estimates with a static gaussian process", {
-  skip_on_cran()
   expect_equal(
     update_Rt(rep(1, 10), log(1.2), rep(0, 9), rep(10, 0), numeric(0), 0),
     rep(1.2, 10)
   )
 })
 test_that("update_Rt works to produce multiple Rt estimates with a non-static gaussian process", {
-  skip_on_cran()
   expect_equal(
     round(update_Rt(rep(1, 10), log(1.2), rep(0.1, 9), rep(10, 0), numeric(0), 0), 2),
     c(1.20, 1.33, 1.47, 1.62, 1.79, 1.98, 2.19, 2.42, 2.67, 2.95)
   )
 })
 test_that("update_Rt works to produce multiple Rt estimates with a non-static stationary gaussian process", {
-  skip_on_cran()
   expect_equal(
     round(update_Rt(rep(1, 10), log(1.2), rep(0.1, 10), rep(10, 0), numeric(0), 1), 3),
     c(1.326, 1.326, 1.326, 1.326, 1.326, 1.326, 1.326, 1.326, 1.326, 1.326)
   )
 })
 test_that("update_Rt works when Rt is fixed", {
-  skip_on_cran()
   expect_equal(
     round(update_Rt(rep(1, 10), log(1.2), numeric(0), rep(10, 0), numeric(0), 0), 2),
     rep(1.2, 10)
@@ -37,7 +32,6 @@ test_that("update_Rt works when Rt is fixed", {
   )
 })
 test_that("update_Rt works when Rt is fixed but a breakpoint is present", {
-  skip_on_cran()
   expect_equal(
     round(update_Rt(rep(1, 5), log(1.2), numeric(0), c(0, 0, 1, 0, 0), 0.1, 0), 2),
     c(1.2, 1.2, rep(1.33, 3))
@@ -52,7 +46,6 @@ test_that("update_Rt works when Rt is fixed but a breakpoint is present", {
   )
 })
 test_that("update_Rt works when Rt is variable and a breakpoint is present", {
-  skip_on_cran()
   expect_equal(
     round(update_Rt(rep(1, 5), log(1.2), rep(0, 4), c(0, 0, 1, 0, 0), 0.1, 0), 2),
     c(1.2, 1.2, rep(1.33, 3))

--- a/tests/testthat/test-stan-secondary.R
+++ b/tests/testthat/test-stan-secondary.R
@@ -1,12 +1,10 @@
-context("estimate_secondary")
-if (!testthat:::on_cran()) {
-  files <- c("pmfs.stan", "convolve.stan", "observation_model.stan", "secondary.stan")
-  suppressMessages(
-    expose_stan_fns(files,
-      target_dir = system.file("stan/functions", package = "EpiNow2")
-    )
+skip_on_cran()
+files <- c("pmfs.stan", "convolve.stan", "observation_model.stan", "secondary.stan")
+suppressMessages(
+expose_stan_fns(files,
+    target_dir = system.file("stan/functions", package = "EpiNow2")
   )
-}
+)
 
 # test primary reports and observations
 reports <- rep(10, 20)
@@ -22,7 +20,6 @@ check_equal <- function(args, target, dof = 0, dev = FALSE) {
 }
 
 test_that("calculate_secondary can calculate prevalence as expected", {
-  skip_on_cran()
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 1, 1, 1, 1, 1, 20),
     target = c(1, 5, 5.5, rep(6, 17)), dof = 1
@@ -30,7 +27,6 @@ test_that("calculate_secondary can calculate prevalence as expected", {
 })
 
 test_that("calculate_secondary can calculate incidence as expected", {
-  skip_on_cran()
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 0, 1, 1, 1, 1, 20),
     target = c(1, 1, 1.5, rep(2.0, 17)), dof = 1
@@ -38,7 +34,6 @@ test_that("calculate_secondary can calculate incidence as expected", {
 })
 
 test_that("calculate_secondary can calculate incidence as expected", {
-  skip_on_cran()
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 0, 1, 1, 1, 1, 20),
     target = c(1, 1, 1.5, rep(2.0, 17)), dof = 1
@@ -46,7 +41,6 @@ test_that("calculate_secondary can calculate incidence as expected", {
 })
 
 test_that("calculate_secondary can calculate incidence using only historic reports", {
-  skip_on_cran()
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 0, 1, 1, 0, 1, 20),
     target = c(0, 0, rep(1, 18)), dof = 0
@@ -54,15 +48,13 @@ test_that("calculate_secondary can calculate incidence using only historic repor
 })
 
 test_that("calculate_secondary can calculate incidence using only current reports", {
-  skip_on_cran()
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 0, 0, 1, 1, 1, 20),
     target = rep(1, 20), dof = 0
   )
 })
 
-test_that("calculate_secondary can switch into prediction mode as expected", {
-  skip_on_cran()
+test_that("calculate_secondary can switch into prediction mode as expected", 
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 1, 0, 1, 1, 1, 20),
     target = c(1, rep(5, 19)), dof = 0

--- a/tests/testthat/test-stan-secondary.R
+++ b/tests/testthat/test-stan-secondary.R
@@ -54,7 +54,7 @@ test_that("calculate_secondary can calculate incidence using only current report
   )
 })
 
-test_that("calculate_secondary can switch into prediction mode as expected", 
+test_that("calculate_secondary can switch into prediction mode as expected", {
   check_equal(
     args = list(reports, obs, 0.1, log(3), 0.1, 5, 1, 0, 1, 1, 1, 20),
     target = c(1, rep(5, 19)), dof = 0


### PR DESCRIPTION
This PR switches to script level skipping for tests that should not be run on CRAN (thanks @bisaloo). It also drops use of `context`