### PR TITLE
Add overdispersion as user facing parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: EpiNow2
 Title: Estimate Real-Time Case Counts and Time-Varying
     Epidemiological Parameters
-Version: 1.3.3.5
+Version: 1.3.3.7
 Authors@R: 
     c(person(given = "Sam",
              family = "Abbott",

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ This release is under development and the features outlined below may change bef
 
 * Added support for varying the length of the day of the week effect (see `obs_opts()`). This allows, for example, fitting to data with cases only reported every 3 days. 
 * Minor optimisations in the observation model by only using the `target` likelihood definition approach when required and in the use of `fmax` and `fmin` over using if statements.
-* Added support for users setting the overdispersion (parameterised as one over the square root of phi) of the reporting process. This is accessible via the `phi` argument of `obs_opts` wit the default of a normal distribution with mean 0 and standard deviation of 1 truncated at 0 remaining unchanged. 
+* Added support for users setting the overdispersion (parameterised as one over the square root of phi) of the reporting process. This is accessible via the `phi` argument of `obs_opts` with the default of a normal distribution with mean 0 and standard deviation of 1 truncated at 0 remaining unchanged. 
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,6 @@
 
 This release is under development and the features outlined below may change before release.
 
-
 ## New features
 
 * Added supported to `simulate_infections` so that a `data.frame` of R samples can be passed in instead of a vector of R values.
@@ -14,6 +13,7 @@ This release is under development and the features outlined below may change bef
 
 * Added support for varying the length of the day of the week effect (see `obs_opts()`). This allows, for example, fitting to data with cases only reported every 3 days. 
 * Minor optimisations in the observation model by only using the `target` likelihood definition approach when required and in the use of `fmax` and `fmin` over using if statements.
+* Added support for users setting the overdispersion (parameterised as one over the square root of phi) of the reporting process. This is accessible via the `phi` argument of `obs_opts` wit the default of a normal distribution with mean 0 and standard deviation of 1 truncated at 0 remaining unchanged. 
 
 ## Documentation
 

--- a/R/create.R
+++ b/R/create.R
@@ -343,8 +343,8 @@ create_gp_data <- function(gp = gp_opts(), data) {
 create_obs_model <- function(obs = obs_opts(), dates) {
   data <- list(
     model_type = ifelse(obs$family %in% "poisson", 0, 1),
-    phi_mean = obs$phi,
-    phi_sd = obs$phi,
+    phi_mean = obs$phi[1],
+    phi_sd = obs$phi[2],
     week_effect = ifelse(obs$week_effect, obs$week_length, 1),
     obs_weight = obs$weight,
     obs_scale = ifelse(length(obs$scale) != 0, 1, 0),

--- a/R/create.R
+++ b/R/create.R
@@ -343,6 +343,8 @@ create_gp_data <- function(gp = gp_opts(), data) {
 create_obs_model <- function(obs = obs_opts(), dates) {
   data <- list(
     model_type = ifelse(obs$family %in% "poisson", 0, 1),
+    phi_mean = obs$phi,
+    phi_sd = obs$phi,
     week_effect = ifelse(obs$week_effect, obs$week_length, 1),
     obs_weight = obs$weight,
     obs_scale = ifelse(length(obs$scale) != 0, 1, 0),
@@ -438,7 +440,9 @@ create_stan_data <- function(reported_cases, generation_time,
   # observation model data
   data <- c(
     data,
-    create_obs_model(obs, dates = reported_cases[(data$seeding_time + 1):.N]$date)
+    create_obs_model(
+      obs, dates = reported_cases[(data$seeding_time + 1):.N]$date
+    )
   )
 
   # rescale mean shifted prior for back calculation if observation scaling is used
@@ -497,7 +501,11 @@ create_initial_conditions <- function(data) {
       out$alpha <- array(truncnorm::rtruncnorm(1, a = 0, mean = 0, sd = data$alpha_sd))
     }
     if (data$model_type == 1) {
-      out$rep_phi <- array(truncnorm::rtruncnorm(1, a = 0, mean = 0, sd = 0.1))
+      out$rep_phi <- array(
+        truncnorm::rtruncnorm(
+          1, a = 0, mean = data$phi_mean, sd = data$phi_sd / 10
+        )
+      )
     }
     if (data$estimate_r == 1) {
       out$initial_infections <- array(rnorm(1, data$prior_infections, 0.02))

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -420,9 +420,8 @@ forecast_secondary <- function(estimate,
   }
 
   # allocate empty parameters
-  data <- allocate_empty(data, 
-                         c("frac_obs", "delay_mean", "delay_sd",
-                           "rep_phi"),
+  data <- allocate_empty(
+    data, c("frac_obs", "delay_mean", "delay_sd", "rep_phi"),
     n = data$n
   )
   data$all_dates <- as.integer(all_dates)

--- a/R/opts.R
+++ b/R/opts.R
@@ -237,6 +237,9 @@ gp_opts <- function(basis_prop = 0.2,
 #' model. Custom settings can be supplied which override the defaults.
 #' @param family Character string defining the observation model. Options are
 #' Negative binomial ("negbin"), the default, and Poisson.
+#' @param phi A numeric vector of length 2, defaults to 0, 1. Indicates the 
+#' mean and standard deviation of the normal prior used for the observation
+#' process.
 #' @param weight Numeric, defaults to 1. Weight to give the observed data in
 #'  the log density.
 #' @param week_effect Logical defaulting to `TRUE`. Should a day of the week effect
@@ -264,14 +267,19 @@ gp_opts <- function(basis_prop = 0.2,
 #' # Scale reported data
 #' obs_opts(scale = list(mean = 0.2, sd = 0.02))
 obs_opts <- function(family = "negbin",
+                     phi = c(0, 1),
                      weight = 1,
                      week_effect = TRUE,
                      week_length = 7,
                      scale = list(),
                      likelihood = TRUE,
                      return_likelihood = FALSE) {
+  if (length(phi) != 2 & !is.numeric(phi)) {
+    stop("phi be numeric and of length two")
+  }
   obs <- list(
     family = match.arg(family, choices = c("poisson", "negbin")),
+    phi = phi,
     weight = weight,
     week_effect = week_effect,
     week_length = week_length,

--- a/R/opts.R
+++ b/R/opts.R
@@ -274,7 +274,7 @@ obs_opts <- function(family = "negbin",
                      scale = list(),
                      likelihood = TRUE,
                      return_likelihood = FALSE) {
-  if (length(phi) != 2 & !is.numeric(phi)) {
+  if (length(phi) != 2 | !is.numeric(phi)) {
     stop("phi be numeric and of length two")
   }
   obs <- list(

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -178,8 +178,8 @@ simulate_infections <- function(estimates,
     data <- c(list(n = dim(draws$R)[1]), draws, estimates$args)
 
     ## allocate empty parameters
-    data <- allocate_empty(data, c("frac_obs", "delay_mean", "delay_sd",
-                                   "rep_phi"),
+    data <- allocate_empty(
+      data, c("frac_obs", "delay_mean", "delay_sd", "rep_phi"),
       n = data$n
     )
 

--- a/inst/stan/data/observation_model.stan
+++ b/inst/stan/data/observation_model.stan
@@ -1,7 +1,7 @@
   int day_of_week[t - seeding_time]; // day of the week indicator (1 - 7)
   int model_type;                    // type of model: 0 = poisson otherwise negative binomial
-  int phi_mean;                      // Mean and sd of the normal prior for the
-  int phi_sd;                        // reporting process
+  real phi_mean;                      // Mean and sd of the normal prior for the
+  real phi_sd;                        // reporting process
   int week_effect;                   // length of week effect
   int truncation;                    // 1/0 indicating if truncation should be adjusted for
   real trunc_mean_mean[truncation];  // truncation mean of mean

--- a/inst/stan/data/observation_model.stan
+++ b/inst/stan/data/observation_model.stan
@@ -1,5 +1,7 @@
   int day_of_week[t - seeding_time]; // day of the week indicator (1 - 7)
   int model_type;                    // type of model: 0 = poisson otherwise negative binomial
+  int phi_mean;                      // Mean and sd of the normal prior for the
+  int phi_sd;                        // reporting process
   int week_effect;                   // length of week effect
   int truncation;                    // 1/0 indicating if truncation should be adjusted for
   real trunc_mean_mean[truncation];  // truncation mean of mean

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -114,7 +114,8 @@ model {
   }
   // observed reports from mean of reports (update likelihood)
   if (likelihood) {
-    report_lp(cases, obs_reports, rep_phi, 1, model_type, obs_weight);
+    report_lp(cases, obs_reports, rep_phi, phi_mean, phi_sd,
+              model_type, obs_weight);
   }
 }
 

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -53,8 +53,8 @@ model {
    }
   // observed secondary reports from mean of secondary reports (update likelihood)
   if (likelihood) {
-    report_lp(obs[(burn_in + 1):t], secondary[(burn_in + 1):t], rep_phi, 1,
-              model_type, 1);
+    report_lp(obs[(burn_in + 1):t], secondary[(burn_in + 1):t],
+              rep_phi, phi_mean, phi_sd, model_type, 1);
   }
 }
 

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -66,12 +66,12 @@ void truncation_lp(real[] truncation_mean, real[] truncation_sd,
 }
 // update log density for reported cases
 void report_lp(int[] cases, vector reports,
-               real[] rep_phi, int phi_prior,
+               real[] rep_phi, int phi_mean, int phi_sd,
                int model_type, real weight) {
   real sqrt_phi = 1e5;
   if (model_type) {
     // the reciprocal overdispersion parameter (phi)
-    rep_phi[model_type] ~ normal(0, phi_prior) T[0,];
+    rep_phi[model_type] ~ normal(phi_mean, phi_sd) T[0,];
     sqrt_phi = 1 / sqrt(rep_phi[model_type]);
     // defer to poisson if phi is large, to avoid overflow or
     // if poisson specified

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -66,7 +66,7 @@ void truncation_lp(real[] truncation_mean, real[] truncation_sd,
 }
 // update log density for reported cases
 void report_lp(int[] cases, vector reports,
-               real[] rep_phi, int phi_mean, int phi_sd,
+               real[] rep_phi, real phi_mean, real phi_sd,
                int model_type, real weight) {
   real sqrt_phi = 1e5;
   if (model_type) {

--- a/inst/stan/functions/secondary.stan
+++ b/inst/stan/functions/secondary.stan
@@ -16,8 +16,8 @@ vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
     scaled_reports = reports;
   }
   // convolve from reports to contributions from these reports
-  conv_reports =
-    conv_reports + convolve_to_report(scaled_reports, delay_mean, delay_sd, max_delay, 0);
+  conv_reports = conv_reports +
+    convolve_to_report(scaled_reports, delay_mean, delay_sd, max_delay, 0);
   // if predicting and using a cumulative target
   // combine reports with previous secondary data
   for (i in 1:t) {
@@ -32,12 +32,12 @@ vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
     // update based on previous primary reports
     if (historic) {
       if (primary_hist_additive) {
-      secondary_reports[i] += conv_reports[i];
+        secondary_reports[i] += conv_reports[i];
       }else{
         if (conv_reports[i] > secondary_reports[i]) {
           conv_reports[i] = secondary_reports[i];
         }
-      secondary_reports[i] -= conv_reports[i];
+        secondary_reports[i] -= conv_reports[i];
       }
     }
     // update based on current primary reports

--- a/man/obs_opts.Rd
+++ b/man/obs_opts.Rd
@@ -6,6 +6,7 @@
 \usage{
 obs_opts(
   family = "negbin",
+  phi = c(0, 1),
   weight = 1,
   week_effect = TRUE,
   week_length = 7,
@@ -17,6 +18,10 @@ obs_opts(
 \arguments{
 \item{family}{Character string defining the observation model. Options are
 Negative binomial ("negbin"), the default, and Poisson.}
+
+\item{phi}{A numeric vector of length 2, defaults to 0, 1. Indicates the
+mean and standard deviation of the normal prior used for the observation
+process.}
 
 \item{weight}{Numeric, defaults to 1. Weight to give the observed data in
 the log density.}

--- a/tests/testthat/test-create_obs_model.R
+++ b/tests/testthat/test-create_obs_model.R
@@ -48,5 +48,5 @@ test_that("create_obs_model can be used with a custom week length", {
 test_that("create_obs_model can be used with a user set phi", {
   obs <- create_obs_model(dates = dates, obs = obs_opts(phi = c(10, 0.1)))
   expect_equal(obs$phi_mean, 10)
-  expect_equal(obs$phi_mean, 0.1)
+  expect_equal(obs$phi_sd, 0.1)
 })

--- a/tests/testthat/test-create_obs_model.R
+++ b/tests/testthat/test-create_obs_model.R
@@ -3,9 +3,9 @@ dates <- seq(as.Date("2020-03-15"), by = "days", length.out = 15)
 
 test_that("create_obs_model works with default settings", {
   obs <- create_obs_model(dates = dates)
-  expect_equal(length(obs), 9)
+  expect_equal(length(obs), 11)
   expect_equal(names(obs), c(
-    "model_type", "week_effect", "obs_weight",
+    "model_type", "phi_mean", "phi_sd", "week_effect", "obs_weight",
     "obs_scale", "likelihood", "return_likelihood",
     "day_of_week", "obs_scale_mean",
     "obs_scale_sd"
@@ -43,4 +43,10 @@ test_that("create_obs_model can be used with no week effect", {
 test_that("create_obs_model can be used with a custom week length", {
   obs <- create_obs_model(dates = dates, obs = obs_opts(week_length = 3))
   expect_equal(obs$day_of_week, c(3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2))
+})
+
+test_that("create_obs_model can be used with a user set phi", {
+  obs <- create_obs_model(dates = dates, obs = obs_opts(phi = c(10, 0.1)))
+  expect_equal(obs$phi_mean, 10)
+  expect_equal(obs$phi_mean, 0.1)
 })

--- a/tests/testthat/test-create_obs_model.R
+++ b/tests/testthat/test-create_obs_model.R
@@ -49,4 +49,6 @@ test_that("create_obs_model can be used with a user set phi", {
   obs <- create_obs_model(dates = dates, obs = obs_opts(phi = c(10, 0.1)))
   expect_equal(obs$phi_mean, 10)
   expect_equal(obs$phi_sd, 0.1)
+  expect_error(obs_opts(phi = c(10)))
+  expect_error(obs_opts(phi = c("Hi", "World")))
 })

--- a/tests/testthat/test-epinow.R
+++ b/tests/testthat/test-epinow.R
@@ -28,7 +28,7 @@ test_that("epinow produces expected output when run with default settings", {
       cores = 1, chains = 2,
       control = list(adapt_delta = 0.8)
     ),
-    logs = NULL
+    logs = NULL, verbose = FALSE
   ))
 
   expect_equal(names(out), expected_out)
@@ -50,7 +50,7 @@ test_that("epinow runs without error when saving to disk", {
       control = list(adapt_delta = 0.8)
     ),
     target_folder = tempdir(check = TRUE),
-    logs = NULL,
+    logs = NULL, verbose = FALSE
   )))
 })
 
@@ -65,7 +65,7 @@ test_that("epinow can produce partial output as specified", {
       control = list(adapt_delta = 0.8)
     ),
     output = c(),
-    logs = NULL
+    logs = NULL, verbose = FALSE
   ))
   expect_equal(names(out), c("estimates", "estimated_reported_cases", "summary"))
   expect_null(out$estimates$samples)
@@ -88,7 +88,7 @@ test_that("epinow fails as expected when given a short timeout", {
       control = list(adapt_delta = 0.8),
       max_execution_time = 10
     ),
-    logs = NULL
+    logs = NULL, verbose = FALSE
   )))
 })
 
@@ -103,7 +103,7 @@ test_that("epinow fails if given NUTs arguments when using variational inference
       cores = 1, chains = 2,
       method = "vb"
     ),
-    logs = NULL
+    logs = NULL, verbose = FALSE
   )))
 })
 
@@ -114,6 +114,6 @@ test_that("epinow fails if given variational inference arguments when using NUTs
     generation_time = generation_time,
     delays = delay_opts(incubation_period, reporting_delay),
     stan = stan_opts(method = "sampling", tol_rel_obj = 1),
-    logs = NULL
+    logs = NULL, verbose = FALSE
   )))
 })

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -11,6 +11,8 @@ reporting_delay <- list(
 )
 
 default_estimate_infections <- function(..., add_stan = list(), delay = TRUE) {
+  futile.logger::flog.threshold("FATAL")
+
   def_stan <- stan_opts(
     chains = 2, warmup = 50, samples = 50,
     control = list(adapt_delta = 0.8)

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -21,7 +21,7 @@ default_estimate_infections <- function(..., add_stan = list(), delay = TRUE) {
   suppressWarnings(estimate_infections(...,
     generation_time = generation_time,
     delays = ifelse(delay, list(delay_opts(reporting_delay)), list(delay_opts()))[[1]],
-    stan = stan_args
+    stan = stan_args, verbose = FALSE
   ))
 }
 

--- a/tests/testthat/test-regional_epinow.R
+++ b/tests/testthat/test-regional_epinow.R
@@ -31,7 +31,7 @@ test_that("regional_epinow produces expected output when run with default settin
         cores = 1, chains = 2,
         control = list(adapt_delta = 0.8)
       ),
-      logs = NULL
+      logs = NULL, verbose = FALSE
     )
   )
   expect_equal(names(out$regional), c("testland", "realland"))
@@ -59,7 +59,7 @@ test_that("regional_epinow runs without error when given a very short timeout", 
         cores = 1, chains = 2,
         control = list(adapt_delta = 0.8),
         max_execution_time = 1
-      ), logs = NULL
+      ), logs = NULL, verbose = FALSE
     ),
     NA
   )
@@ -72,7 +72,7 @@ test_that("regional_epinow runs without error when given a very short timeout", 
         cores = 1, chains = 2,
         control = list(adapt_delta = 0.8),
         max_execution_time = 1, future = TRUE
-      ), logs = NULL
+      ), logs = NULL, verbose = FALSE
     ),
     NA
   )
@@ -93,7 +93,7 @@ test_that("regional_epinow produces expected output when run with region specifi
         cores = 1, chains = 2,
         control = list(adapt_delta = 0.8)
       ),
-      logs = NULL
+      logs = NULL, verbose = FALSE
     )
   )
   expect_equal(names(out$regional), c("testland", "realland"))

--- a/tests/testthat/test-simulate_infections.R
+++ b/tests/testthat/test-simulate_infections.R
@@ -17,7 +17,8 @@ out <- suppressWarnings(estimate_infections(reported_cases,
     stan = stan_opts(
       chains = 2, warmup = 100, samples = 100,
       control = list(adapt_delta = 0.9)
-    )
+    ), 
+    verbose = FALSE
 ))
 
 


### PR DESCRIPTION
This PR adds the overdispersion prior (which is scaled as 1 over the square root) as a user facing prior with no change to the package defaults. This allows users to update this based on prior knowledge etc. The aim of this additon is to be observation model agnostic so that future updates can use this parameter to set priors for other observation family parameters. 