### PR TITLE
ensure correct parameters if `use_rt=FALSE`

### DIFF
--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -205,6 +205,10 @@ estimate_infections <- function(reported_cases,
   # store dirty reported case data
   dirty_reported_cases <- data.table::copy(reported_cases)
 
+  if (!rt$use_rt) {
+    rt <- NULL
+  }
+
   # Check verbose settings and set logger to match
   if (verbose) {
     futile.logger::flog.threshold(futile.logger::DEBUG,


### PR DESCRIPTION
Not ideal as if the user specifies some options with `rt_opts` they will just get overridden. In return it doesn't throw a cryptic error. Not sure at all whether this is better than the current set up but I couldn't think of anything better.

Address #273. 