### PR TITLE
ensure seeding_time is at least max_gt

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -387,6 +387,9 @@ create_stan_data <- function(reported_cases, generation_time,
                              rt, gp, obs, delays, horizon,
                              backcalc, shifted_cases,
                              truncation) {
+  ## make sure we have at least max_gt seeding time
+  delays$seeding_time <- max(delays$seeding_time, generation_time$max)
+
   cases <- reported_cases[(delays$seeding_time + 1):(.N - horizon)]$confirm
 
   data <- list(

--- a/tests/testthat/test-simulate_infections.R
+++ b/tests/testthat/test-simulate_infections.R
@@ -52,7 +52,7 @@ test_that("simulate infections fails as expected", {
 })
 
 test_that("simulate_infections works to simulate a passed in estimate_infections object with an adjusted Rt in data frame", {
-  R <- c(rep(NA_real_, 40), rep(0.5, 17))
+  R <- c(rep(NA_real_, 32), rep(0.5, 17))
   R_dt <- data.frame(date = summary(out, type = "parameters", param = "R")$date, value = R)
   sims_dt <- simulate_infections(out, R_dt)
   expect_equal(names(sims_dt), c("samples", "summarised", "observations"))


### PR DESCRIPTION
Without this there can be initial artefacts when not using delays