### PR TITLE
option for secondary baseline

### DIFF
--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -238,7 +238,8 @@ secondary_opts <- function(type = "incidence", ...) {
       historic = 1,
       primary_hist_additive = 1,
       current = 0,
-      primary_current_additive = 0
+      primary_current_additive = 0,
+      estimate_baseline = 0
     )
   } else if (type %in% "prevalence") {
     data <- list(
@@ -246,7 +247,8 @@ secondary_opts <- function(type = "incidence", ...) {
       historic = 1,
       primary_hist_additive = 0,
       current = 1,
-      primary_current_additive = 1
+      primary_current_additive = 1,
+      estimate_baseline = 0
     )
   }
   data <- update_list(data, list(...))
@@ -427,7 +429,8 @@ forecast_secondary <- function(estimate,
 
   # allocate empty parameters
   data <- allocate_empty(
-    data, c("frac_obs", "delay_mean", "delay_sd", "rep_phi"),
+    data, c("frac_obs", "delay_mean", "delay_sd", "rep_phi",
+            "secondary_baseline"),
     n = data$n
   )
   data$all_dates <- as.integer(all_dates)

--- a/inst/stan/data/secondary.stan
+++ b/inst/stan/data/secondary.stan
@@ -4,3 +4,4 @@
   int primary_hist_additive;         // Should historic primary reports be additive
   int current;                       // Should current primary reports be considered
   int primary_current_additive;      // Should current primary reports be additive
+  int estimate_baseline;             // Should a baseline be estimated

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -24,14 +24,15 @@ parameters{
   real truncation_mean[truncation];      // mean of truncation
   real truncation_sd[truncation];        // sd of truncation
   real<lower = 0> rep_phi[model_type];   // overdispersion of the reporting process
+  real<lower = 0> secondary_baseline[estimate_baseline]; // baseline for secondary component
 }
 
 transformed parameters {
   vector<lower=0>[t] secondary;
   // calculate secondary reports from primary
-  secondary = calculate_secondary(primary, obs, frac_obs, delay_mean,
-                                  delay_sd, max_delay, cumulative,
-                                  historic, primary_hist_additive,
+  secondary = calculate_secondary(primary, obs, frac_obs, secondary_baseline,
+                                  delay_mean, delay_sd, max_delay,
+                                  cumulative, historic, primary_hist_additive,
                                   current, primary_current_additive, t);
  // weekly reporting effect
  if (week_effect > 1) {
@@ -42,6 +43,9 @@ transformed parameters {
 }
 
 model {
+  if (estimate_baseline) {
+    secondary_baseline[1] ~ normal(0, min(obs)) T[0, ];
+  }
   // penalised priors for delay distributions
   delays_lp(delay_mean, delay_mean_mean, delay_mean_sd, delay_sd, delay_sd_mean, delay_sd_sd, 1);
   // priors for truncation

--- a/inst/stan/functions/secondary.stan
+++ b/inst/stan/functions/secondary.stan
@@ -1,8 +1,8 @@
 // Calculate secondary reports condition only on primary reports
 vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
-                           real[] delay_mean, real[] delay_sd,
-                           int[] max_delay, int cumulative, int historic,
-                           int primary_hist_additive, int current,
+                           real[] secondary_baseline, real[] delay_mean,
+                           real[] delay_sd, int[] max_delay, int cumulative,
+                           int historic, int primary_hist_additive, int current,
                            int primary_current_additive, int predict) {
   int t = num_elements(reports);
   int obs_scale = num_elements(frac_obs);
@@ -47,6 +47,9 @@ vector calculate_secondary(vector reports, int[] obs, real[] frac_obs,
       }else{
         secondary_reports[i] -= scaled_reports[i];
       }
+    }
+    if (num_elements(secondary_baseline) > 0) {
+      secondary_reports[i] += secondary_baseline[1];
     }
     secondary_reports[i] = fmax(1e-5, secondary_reports[i]);
   }

--- a/inst/stan/simulate_secondary.stan
+++ b/inst/stan/simulate_secondary.stan
@@ -14,11 +14,14 @@ data {
   // secondary model specific data
   int<lower = 0> obs[t - h];         // observed secondary data
   matrix[n, t] primary;              // observed primary data
+
 #include data/secondary.stan
   // delay from infection to report
 #include data/simulation_delays.stan
   // observation model
 #include data/simulation_observation_model.stan
+
+  real secondary_baseline[n,estimate_baseline];
 }
 
 generated quantities {
@@ -27,9 +30,10 @@ generated quantities {
     vector[t] secondary;
     // calculate secondary reports from primary
     secondary =
-       calculate_secondary(to_vector(primary[i]), obs, frac_obs[i], delay_mean[i],
-                           delay_sd[i], max_delay, cumulative,
-                           historic, primary_hist_additive,
+       calculate_secondary(to_vector(primary[i]), obs, frac_obs[i],
+                           secondary_baseline[i],
+                           delay_mean[i], delay_sd[i], max_delay,
+                           cumulative, historic, primary_hist_additive,
                            current, primary_current_additive, t - h + 1);
     // weekly reporting effect
     if (week_effect > 1) {


### PR DESCRIPTION
Adds a baseline level to the secondary model, i.e. a constant component that is not affected by the primary data stream (somewhat akin to the endemic component in `hhh4`. This was motivated by observations that the model currently seems quite a long way off the data in some countries (though not all) in the European Forecast Hub submissions. When inspecting some of the raw data on cases and admissions, the relationship seemed reasonably close to linear but with an intercept at >0. 

Visually, the updated model connects somewhat better to recent data (if not impressively so, possibly because still fitting to a mixture of Delta and Omicron), but it comes at the expense of less straightforward epidemiological interpretation of the estimated delay and scaling - happy to hear of other suggestions that could improve things.

From https://github.com/sophiemeakin/ecdc-covid19-admissions/blob/main/main.R

Without baseline:
<img width="1480" alt="image" src="https://user-images.githubusercontent.com/1156307/152038437-e1ec5ed6-c1ab-4b5c-a89c-12179fa0af3f.png">

With baseline:
<img width="1487" alt="image" src="https://user-images.githubusercontent.com/1156307/152039234-0605e987-ea8c-45f3-bf4b-5d79e792fb61.png">
