### PR TITLE
don't pass R to update_Rt

### DIFF
--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -69,7 +69,7 @@ transformed parameters {
     // via Rt
     real set_gt_mean = (gt_mean_sd > 0 ? gt_mean[1] : gt_mean_mean);
     real set_gt_sd = (gt_sd_sd > 0 ? gt_sd[1] : gt_sd_mean);
-    R = update_Rt(R, log_R[estimate_r], noise, breakpoints, bp_effects, stationary);
+    R = update_Rt(ot_h, log_R[estimate_r], noise, breakpoints, bp_effects, stationary);
     infections = generate_infections(R, seeding_time, set_gt_mean, set_gt_sd, max_gt,
                                      initial_infections, initial_growth,
                                      pop, future_time);

--- a/inst/stan/functions/rt.stan
+++ b/inst/stan/functions/rt.stan
@@ -1,8 +1,7 @@
 // update a vector of Rts
-vector update_Rt(vector input_R, real log_R, vector noise, int[] bps,
+vector update_Rt(int t, real log_R, vector noise, int[] bps,
                  real[] bp_effects, int stationary) {
   // define control parameters
-  int t = num_elements(input_R);
   int bp_n = num_elements(bp_effects);
   int bp_c = 0;
   int gp_n = num_elements(noise);


### PR DESCRIPTION
This slightly simplifies the call to `update_R` (also reducing the amount of memory copying required) - the function never uses the contents of `R`, just its length, which is stored in a separate variable.