### PR TITLE
only call truncate if truncation is modelled

### DIFF
--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -122,14 +122,14 @@ estimate_truncation <- function(obs, max_truncation = 10,
     obs_dist = obs_dist,
     t = nrow(obs_data),
     obs_sets = ncol(obs_data),
-    trunc_max = array(max_truncation)
+    trunc_max = max_truncation
   )
 
   # initial conditions
   init_fn <- function() {
     data <- list(
-      logmean = array(rnorm(1, 0, 1)),
-      logsd = array(abs(rnorm(1, 0, 1))),
+      logmean = rnorm(1, 0, 1),
+      logsd = abs(rnorm(1, 0, 1)),
       phi = abs(rnorm(1, 0, 1))
     )
     return(data)

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -88,8 +88,12 @@ transformed parameters {
    reports = scale_obs(reports, frac_obs[1]);
  }
  // truncate near time cases to observed reports
- obs_reports = truncate(reports[1:ot], truncation_mean, truncation_sd,
-                        max_truncation, 0);
+ if (truncation) {
+   obs_reports = truncate(reports[1:ot], truncation_mean[1], truncation_sd[1],
+                          max_truncation[1], 0);
+ } else {
+   obs_reports = reports[1:ot];
+ }
 }
 
 model {

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -38,7 +38,9 @@ transformed parameters {
    secondary = day_of_week_effect(secondary, day_of_week, day_of_week_simplex);
   }
  // truncate near time cases to observed reports
- secondary = truncate(secondary, truncation_mean, truncation_sd, max_truncation, 0);
+ if (truncation) {
+   secondary = truncate(secondary, truncation_mean[1], truncation_sd[1], max_truncation[1], 0);
+ }
 }
 
 model {

--- a/inst/stan/estimate_truncation.stan
+++ b/inst/stan/estimate_truncation.stan
@@ -7,15 +7,15 @@ data {
   int obs_sets;
   int obs[t, obs_sets];
   int obs_dist[obs_sets];
-  int trunc_max[1];
+  int trunc_max;
 }
 parameters {
-  real logmean[1];
-  real<lower=0> logsd[1];
+  real logmean;
+  real<lower=0> logsd;
   real<lower=0> phi;
 }
 transformed parameters{
-  matrix[trunc_max[1], obs_sets - 1] trunc_obs;
+  matrix[trunc_max, obs_sets - 1] trunc_obs;
   real sqrt_phi = 1 / sqrt(phi);
   {
   vector[t] last_obs;
@@ -24,7 +24,7 @@ transformed parameters{
   // apply truncation to latest dataset to map back to previous data sets
   for (i in 1:(obs_sets - 1)) {
    int end_t = t - obs_dist[i];
-   int start_t = end_t - trunc_max[1] + 1;
+   int start_t = end_t - trunc_max + 1;
    trunc_obs[, i] = truncate(last_obs[start_t:end_t], logmean, logsd,
                              trunc_max, 0);
    }
@@ -33,26 +33,30 @@ transformed parameters{
 model {
   // priors for the log normal truncation distribution
   logmean ~ normal(0, 1);
-  logsd[1] ~ normal(0, 1) T[0,];
+  logsd ~ normal(0, 1) T[0,];
   phi ~ normal(0, 1) T[0,];
   // log density of truncated latest data vs that observed
   for (i in 1:(obs_sets - 1)) {
-    int start_t = t - obs_dist[i] - trunc_max[1];
-    for (j in 1:trunc_max[1]) {
+    int start_t = t - obs_dist[i] - trunc_max;
+    for (j in 1:trunc_max) {
       obs[start_t + j, i] ~ neg_binomial_2(trunc_obs[j, i], sqrt_phi);
     }
   }
 }
 generated quantities {
-  matrix[trunc_max[1], obs_sets] recon_obs;
-  vector[trunc_max[1]] cmf;
+  matrix[trunc_max, obs_sets] recon_obs;
+  matrix[trunc_max, obs_sets - 1] gen_obs;
+  vector[trunc_max] cmf;
   // reconstruct all truncated datasets using posterior of the truncation distribution
   for (i in 1:obs_sets) {
     int end_t = t - obs_dist[i];
-    int start_t = end_t - trunc_max[1] + 1;
+    int start_t = end_t - trunc_max + 1;
     recon_obs[, i] = truncate(to_vector(obs[start_t:end_t, i]), logmean, logsd, trunc_max, 1);
   }
-  // generate a posterior for the cmf of the truncation distribution
-  cmf = truncation_cmf(logmean[1], logsd[1], trunc_max[1]);
+ // generate observations for comparing
+  for (i in 1:(obs_sets - 1)) {
+    gen_obs[, i] = to_vector(neg_binomial_2_rng(trunc_obs[, i], sqrt_phi));
+  }
+ // generate a posterior for the cmf of the truncation distribution
+ cmf = truncation_cmf(logmean, logsd, trunc_max);
 }
-

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -33,24 +33,20 @@ vector truncation_cmf(real trunc_mean, real trunc_sd, int trunc_max) {
     return(cmf);
 }
 // Truncate observed data by some truncation distribution
-vector truncate(vector reports, real[] truncation_mean, real[] truncation_sd,
-                int[] truncation_max, int reconstruct) {
+vector truncate(vector reports, real truncation_mean, real truncation_sd,
+                int truncation_max, int reconstruct) {
   int t = num_elements(reports);
-  int truncation = num_elements(truncation_mean);
   vector[t] trunc_reports = reports;
-  if (truncation) {
-    // Calculate cmf of truncation delay
-    int trunc_max = truncation_max[1] > t ? t : truncation_max[1];
-    int  trunc_indexes[trunc_max];
-    vector[trunc_max] cmf;
-    int first_t = t - trunc_max + 1;
-    cmf = truncation_cmf(truncation_mean[1], truncation_sd[1], trunc_max);
-    // Apply cdf of truncation delay to truncation max last entries in reports
-    if (reconstruct) {
-      trunc_reports[first_t:t] = trunc_reports[first_t:t] ./ cmf;
-    }else{
-      trunc_reports[first_t:t] = trunc_reports[first_t:t] .* cmf;
-    }
+  // Calculate cmf of truncation delay
+  int trunc_max = truncation_max > t ? t : truncation_max;
+  vector[trunc_max] cmf;
+  int first_t = t - trunc_max + 1;
+  cmf = truncation_cmf(truncation_mean, truncation_sd, trunc_max);
+  // Apply cdf of truncation delay to truncation max last entries in reports
+  if (reconstruct) {
+    trunc_reports[first_t:t] = trunc_reports[first_t:t] ./ cmf;
+  }else{
+    trunc_reports[first_t:t] = trunc_reports[first_t:t] .* cmf;
   }
   return(trunc_reports);
 }


### PR DESCRIPTION
This simplifies the call to `truncate` in `estimate_infections`, only calling it when truncation is actually required. This seems more intuitive as the call to `truncate` was previously required even if no truncation was applied, but only to create an `obs_report` variable not containing the forecasts. This now follows the same logic as e.g. only applying scaling if `obs_scale` is set to 1, such that the decision of whether truncation is applied is now happening outside the `truncate` function, which now always truncates.

As a (positive, in my opinion) side effect this does away with having to pass vectors to the `truncate` function requiring declarations of vectors of size 1 in `estimate_truncation`.