### PR TITLE
fix estimate_secondary example

### DIFF
--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -59,6 +59,28 @@
 #' # Parameters of the assumed log normal delay distribution
 #' cases[, meanlog := 1.8][, sdlog := 0.5]
 #'
+#' # apply a convolution of a log normal to a vector of observations
+#' weight_cmf <- function(x, ...) {
+#'   set.seed(x[1])
+#'   meanlog <- rnorm(1, 1.6, 0.2)
+#'   sdlog <- rnorm(1, 0.8, 0.1)
+#'   cmf <- cumsum(dlnorm(1:length(x), meanlog, sdlog)) -
+#'     cumsum(dlnorm(0:(length(x) - 1), meanlog, sdlog))
+#'   cmf <- cmf / plnorm(length(x), meanlog, sdlog)
+#'   conv <- sum(x * rev(cmf), na.rm = TRUE)
+#'   conv <- round(conv, 0)
+#'   return(conv)
+#' }
+#' # roll over observed cases to produce a convolution
+#' cases <- cases[, .(date, primary = confirm, secondary = confirm)]
+#' cases <- cases[, secondary := frollapply(secondary, 15, weight_cmf, align = "right")]
+#' cases <- cases[!is.na(secondary)]
+#' # add a day of the week effect and scale secondary observations at 40\% of primary
+#' cases <- cases[lubridate::wday(date) == 1, secondary := round(0.5 * secondary, 0)]
+#' cases <- cases[, secondary := round(secondary * rnorm(.N, 0.4, 0.025), 0)]
+#' cases <- cases[secondary < 0, secondary := 0]
+#' cases <- cases[, secondary := map_dbl(secondary, ~ rpois(1, .))]
+#'
 #' # fit model to example data assuming only a given fraction of primary observations
 #' # become secondary observations
 #' inc <- estimate_secondary(cases[1:60],

--- a/man/estimate_secondary.Rd
+++ b/man/estimate_secondary.Rd
@@ -91,6 +91,28 @@ cases[, scaling := 0.4]
 # Parameters of the assumed log normal delay distribution
 cases[, meanlog := 1.8][, sdlog := 0.5]
 
+# apply a convolution of a log normal to a vector of observations
+weight_cmf <- function(x, ...) {
+  set.seed(x[1])
+  meanlog <- rnorm(1, 1.6, 0.2)
+  sdlog <- rnorm(1, 0.8, 0.1)
+  cmf <- cumsum(dlnorm(1:length(x), meanlog, sdlog)) -
+    cumsum(dlnorm(0:(length(x) - 1), meanlog, sdlog))
+  cmf <- cmf / plnorm(length(x), meanlog, sdlog)
+  conv <- sum(x * rev(cmf), na.rm = TRUE)
+  conv <- round(conv, 0)
+  return(conv)
+}
+# roll over observed cases to produce a convolution
+cases <- cases[, .(date, primary = confirm, secondary = confirm)]
+cases <- cases[, secondary := frollapply(secondary, 15, weight_cmf, align = "right")]
+cases <- cases[!is.na(secondary)]
+# add a day of the week effect and scale secondary observations at 40\\% of primary
+cases <- cases[lubridate::wday(date) == 1, secondary := round(0.5 * secondary, 0)]
+cases <- cases[, secondary := round(secondary * rnorm(.N, 0.4, 0.025), 0)]
+cases <- cases[secondary < 0, secondary := 0]
+cases <- cases[, secondary := map_dbl(secondary, ~ rpois(1, .))]
+
 # fit model to example data assuming only a given fraction of primary observations
 # become secondary observations
 inc <- estimate_secondary(cases[1:60],


### PR DESCRIPTION
Partially reverts https://github.com/epiforecasts/EpiNow2/commit/41dd4e8e80435e95dc9642828bd345c6fad2d313 to make sure the `estimate_secondary` example works.

Thanks to @seabbs for highlighting this in https://github.com/epiforecasts/EpiNow2/pull/309#discussion_r978025028.