### PR TITLE
Add tests adjust to report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -131,6 +131,7 @@ LinkingTo:
     rstan (>= 2.21.1),
     StanHeaders (>= 2.21.0-5)
 Biarch: true
+Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: true

--- a/NEWS.md
+++ b/NEWS.md
@@ -35,6 +35,7 @@ Thanks to @Bisaloo, @hsbadr, @LloydChapman, @medewitt, and @sbfnk.
 * Switched from `cowplot::theme_cowplot()` to `ggplot2::theme_bw()`. This allows the removal of `cowplot` as a dependency as well making plots visuable for users saving as pngs and using a dark theme. By @seabbs.
 * By default `epinow` and downstream functions remove leading zeros. Now this is optional with the new `filter_leading_zeros` option. Thanks to @LloydChapman in #285.
 * Basic tests have been added to cover `estimate_secondary()`, `forecast_secondary()`, and `estimate_truncation()`. By @seabbs in #315.
+* Add basic snapshot tests for `adjust_infection_to_report`. By @seabbs in #316.
 
 ## Other changes
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,6 @@
 url: epiforecasts.io/EpiNow2/
 template:
+  bootstrap: 5
   opengraph:
     image:
       src: man/figures/unnamed-chunk-13-1.png
@@ -15,7 +16,7 @@ template:
       index_name: epinow2
 
 development:
-  mode: release
+  mode: auto
 
 authors:
   Sam Abbott:

--- a/tests/testthat/_snaps/adjust_infection_to_report.md
+++ b/tests/testthat/_snaps/adjust_infection_to_report.md
@@ -1,0 +1,38 @@
+# adjust_infection_to_report can correctly handle a simple mapping
+
+    Code
+      adjust_infection_to_report(cases, delay_defs = list(incubation_def, delay_def))
+    Output
+                 date cases
+        1: 2020-02-24     1
+        2: 2020-02-25     3
+        3: 2020-02-26     7
+        4: 2020-02-27    11
+        5: 2020-02-28    24
+       ---                 
+      124: 2020-06-26   233
+      125: 2020-06-27   235
+      126: 2020-06-28   261
+      127: 2020-06-29   281
+      128: 2020-06-30   266
+
+# adjust_infection_to_report can correctly handle a mapping with a day
+           of the week effect
+
+    Code
+      adjust_infection_to_report(cases, delay_defs = list(incubation_def, delay_def),
+      reporting_effect = c(1.1, rep(1, 4), 0.95, 0.95))
+    Output
+                 date cases
+        1: 2020-02-25     1
+        2: 2020-02-26     8
+        3: 2020-02-27    13
+        4: 2020-02-28    27
+        5: 2020-02-29    38
+       ---                 
+      123: 2020-06-26   234
+      124: 2020-06-27   224
+      125: 2020-06-28   238
+      126: 2020-06-29   297
+      127: 2020-06-30   267
+

--- a/tests/testthat/test-adjust_infection_to_report.R
+++ b/tests/testthat/test-adjust_infection_to_report.R
@@ -1,0 +1,32 @@
+ # define example cases
+ cases <- data.table::copy(example_confirmed)[, cases := as.integer(confirm)]
+
+ # define a single report delay distribution
+ delay_def <- lognorm_dist_def(
+   mean = 5, mean_sd = 1, sd = 3, sd_sd = 1,
+   max_value = 30, samples = 1, to_log = TRUE
+ )
+
+ # define a single incubation period
+ incubation_def <- lognorm_dist_def(
+   mean = incubation_periods[1, ]$mean,
+   mean_sd = incubation_periods[1, ]$mean_sd,
+   sd = incubation_periods[1, ]$sd,
+   sd_sd = incubation_periods[1, ]$sd_sd,
+   max_value = 30, samples = 1
+ )
+
+test_that("adjust_infection_to_report can correctly handle a simple mapping", {
+  expect_snapshot(adjust_infection_to_report(
+    cases, delay_defs = list(incubation_def, delay_def)
+  ))
+})
+
+test_that("adjust_infection_to_report can correctly handle a mapping with a day
+           of the week effect", {
+  expect_snapshot(adjust_infection_to_report(
+    cases,
+    delay_defs = list(incubation_def, delay_def),
+    reporting_effect = c(1.1, rep(1, 4), 0.95, 0.95)
+  ))
+})

--- a/tests/testthat/test-estimate_secondary copy.R
+++ b/tests/testthat/test-estimate_secondary copy.R
@@ -1,0 +1,62 @@
+ skip_on_cran()
+ library(data.table)
+
+ # make some example secondary incidence data
+ cases <- example_confirmed
+ cases <- as.data.table(cases)[, primary := confirm]
+ # Assume that only 40 percent of cases are reported
+ cases[, scaling := 0.4]
+ # Parameters of the assumed log normal delay distribution
+ cases[, meanlog := 1.8][, sdlog := 0.5]
+
+ # apply a convolution of a log normal to a vector of observations
+ weight_cmf <- function(x, ...) {
+   set.seed(x[1])
+   meanlog <- rnorm(1, 1.6, 0.2)
+   sdlog <- rnorm(1, 0.8, 0.1)
+   cmf <- cumsum(dlnorm(1:length(x), meanlog, sdlog)) -
+     cumsum(dlnorm(0:(length(x) - 1), meanlog, sdlog))
+   cmf <- cmf / plnorm(length(x), meanlog, sdlog)
+   conv <- sum(x * rev(cmf), na.rm = TRUE)
+   conv <- round(conv, 0)
+   return(conv)
+ }
+ # roll over observed cases to produce a convolution
+ cases <- cases[, .(date, primary = confirm, secondary = confirm)]
+ cases <- cases[, secondary := frollapply(secondary, 15, weight_cmf, align = "right")]
+ cases <- cases[!is.na(secondary)]
+ # add a day of the week effect and scale secondary observations at 40\% of primary
+ cases <- cases[lubridate::wday(date) == 1, secondary := round(0.5 * secondary, 0)]
+ cases <- cases[, secondary := round(secondary * rnorm(.N, 0.4, 0.025), 0)]
+ cases <- cases[secondary < 0, secondary := 0]
+ cases <- cases[, secondary := map_dbl(secondary, ~ rpois(1, .))]
+
+ # fit model to example data assuming only a given fraction of primary observations
+ # become secondary observations
+ inc <- estimate_secondary(cases[1:60],
+   obs = obs_opts(scale = list(mean = 0.2, sd = 0.2)),
+   chains = 2, warmup = 250, iter = 750, cores = 2,
+   refresh = 0
+ )
+
+test_that("estimate_secondary can return values from simulated data and plot
+           them", {
+  expect_equal(names(inc), c("predictions", "data", "fit"))
+  expect_equal(
+    names(inc$predictions),
+    c("date", "primary", "secondary", "mean", "se_mean", "sd", "lower_90",
+      "lower_50", "lower_20", "median", "upper_20", "upper_50", "upper_90"
+    )
+  )
+  expect_true(is.list(inc$data))
+  # validation plot of observations vs estimates
+  expect_error(plot(inc, primary = TRUE), NA)
+})
+
+test_that("forecast_secondary can return values from simulated data and plot
+           them", {
+  inc_preds <- forecast_secondary(inc, cases[61:.N][, value := primary])
+  expect_equal(names(inc_preds), c("samples", "forecast", "predictions"))
+  # validation plot of observations vs estimates
+  expect_error(plot(inc_preds, new_obs = cases, from = "2020-05-01"), NA)
+})


### PR DESCRIPTION
- Updates `pkgdown` version
- Adds a basic snapshot test for `adjust_infection_to_report`. This will likely be depreciated in the future, but a minimal test helps reassure that things are working as expected.