### PR TITLE
bug fix: return_likelihood check

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -68,6 +68,7 @@ estimates and are considered out of scope for `EpiNow2`. If finding useful conta
 * Fixed a bug where `use_rt = FALSE` did not properly cancel user settings. By @sbfnk.
 * Fixed a bug in `estimate_truncation` where phi was not initialised. By @sbfnk.
 * Fixed a bug where `zero_threshold` was being ignored and so no post-processing was happening. To maintain backwards compatibility the default has been changed to `Inf` (i.e. no zero threshold). By @LloydChapman in #285.
+* Fixed a bug where setting `obs_opts(return_likelihood = TRUE)` fails. By @sbfnk in #333.
 
 # EpiNow2 1.3.2
 

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -141,7 +141,7 @@ generated quantities {
   int imputed_reports[ot_h];
   vector[estimate_r > 0 ? 0: ot_h] gen_R;
   real r[ot_h];
-  vector[return_likelihood > 1 ? ot : 0] log_lik;
+  vector[return_likelihood ? ot : 0] log_lik;
   if (estimate_r){
     // estimate growth from estimated Rt
     real set_gt_mean = (gt_mean_sd > 0 ? gt_mean[1] : gt_mean_mean);


### PR DESCRIPTION
`return_likelihood` is never greater than 1 - so at the moment setting `return_likelihood = TRUE` results in failure because `log_lik` has size 0.