### PR TITLE
 upper bound `frac_obs` by 1 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Model changes
 
+* The range of the `frac_obs` parameter has restricted with an upper bound of 1 to reflect its name and description. By @sbfnk in #340.
+
 ## Documentation
 
 * Updated examples to make use of fixed distributions to improve run-times where appropriate.

--- a/R/create.R
+++ b/R/create.R
@@ -563,7 +563,7 @@ create_initial_conditions <- function(data) {
     }
     if (data$obs_scale == 1) {
       out$frac_obs <- array(truncnorm::rtruncnorm(1,
-        a = 0,
+        a = 0, b = 1,
         mean = data$obs_scale_mean,
         sd = data$obs_scale_sd * 0.1
       ))

--- a/inst/stan/data/simulation_observation_model.stan
+++ b/inst/stan/data/simulation_observation_model.stan
@@ -2,6 +2,6 @@
   int week_effect;                   // should a day of the week effect be estimated
   real<lower = 0> day_of_week_simplex[n, week_effect];
   int obs_scale;
-  real frac_obs[n, obs_scale];
+  real<lower = 0, upper = 1> frac_obs[n, obs_scale];
   int model_type;
   real<lower = 0> rep_phi[n, model_type];  // overdispersion of the reporting process

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -76,7 +76,7 @@ parameters{
   real delay_mean[n_uncertain_mean_delays];         // mean of delays
   real<lower = 0> delay_sd[n_uncertain_sd_delays];  // sd of delays
   simplex[week_effect] day_of_week_simplex;// day of week reporting effect
-  real<lower = 0> frac_obs[obs_scale];     // fraction of cases that are ultimately observed
+  real<lower = 0, upper = 1> frac_obs[obs_scale];     // fraction of cases that are ultimately observed
   real trunc_mean[truncation && !trunc_fixed[1]];        // mean of truncation
   real<lower = 0> trunc_sd[truncation && !trunc_fixed[1]]; // sd of truncation
   real<lower = 0> rep_phi[model_type];     // overdispersion of the reporting process
@@ -164,7 +164,7 @@ model {
   }
   // prior observation scaling
   if (obs_scale) {
-    frac_obs[1] ~ normal(obs_scale_mean, obs_scale_sd) T[0,];
+    frac_obs[1] ~ normal(obs_scale_mean, obs_scale_sd) T[0, 1];
   }
   // observed reports from mean of reports (update likelihood)
   if (likelihood) {

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -46,7 +46,7 @@ parameters{
   real delay_mean[n_uncertain_mean_delays];               // mean of delays
   real<lower = 0> delay_sd[n_uncertain_sd_delays];      // sd of delays
   simplex[week_effect] day_of_week_simplex;  // day of week reporting effect
-  real<lower = 0> frac_obs[obs_scale];   // fraction of cases that are ultimately observed
+  real<lower = 0, upper = 1> frac_obs[obs_scale];   // fraction of cases that are ultimately observed
   real trunc_mean[truncation];      // mean of truncation
   real trunc_sd[truncation];        // sd of truncation
   real<lower = 0> rep_phi[model_type];   // overdispersion of the reporting process
@@ -93,7 +93,7 @@ model {
                 trunc_sd_mean, trunc_sd_sd);
   // prior primary report scaling
   if (obs_scale) {
-    frac_obs[1] ~ normal(obs_scale_mean, obs_scale_sd) T[0,];
+    frac_obs[1] ~ normal(obs_scale_mean, obs_scale_sd) T[0, 1];
    }
   // observed secondary reports from mean of secondary reports (update likelihood)
   if (likelihood) {


### PR DESCRIPTION
As currently described ("fraction...that are ultimately observed") the `frac_obs` variable should have an upper bound of 1. This helps constraining it when using `estimate_secondary` to estimate the scaling between two time serires.

There might be use cases where one would want to allow the parameter to extend beyond 1, in which case the upper bound could be made optional and the parameter description/name changed.