### PR TITLE
Revise the examples for `create_backcalc_data()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: EpiNow2
 Title: Estimate Real-Time Case Counts and Time-Varying
     Epidemiological Parameters
-Version: 1.3.6.3000
+Version: 1.3.6.4000
 Authors@R: 
     c(person(given = "Sam",
              family = "Abbott",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# EpiNow2 1.3.6.3000
+# EpiNow2 1.3.6
 
 This release is in development. For a stable release install 1.3.5 from CRAN.
 
@@ -12,8 +12,8 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
   mean close or equal to 0. By @sbfnk in #366.
 * Replaced use of nested `ifelse()` and `data.table::fifelse()` in the
   code base with `data.table::fcase()`. By @jamesmbaazam in #383 and reviewed by @seabbs.
-* Revised the example in `calc_backcalc_data()` to call `calc_backcalc_data()`
-  instead of `create_gp_data()`. By @jamesmbaazam in #388 and review by @seabbs.
+* Reviewed the example in `calc_backcalc_data()` to call `calc_backcalc_data()`
+  instead of `create_gp_data()`. By @jamesmbaazam in #388 and reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-# EpiNow2 1.3.6
+# EpiNow2 1.3.6.3000
 
 This release is in development. For a stable release install 1.3.5 from CRAN.
 
@@ -12,6 +12,8 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
   mean close or equal to 0. By @sbfnk in #366.
 * Replaced use of nested `ifelse()` and `data.table::fifelse()` in the
   code base with `data.table::fcase()`. By @jamesmbaazam in #383 and reviewed by @seabbs.
+* Revised the example in `calc_backcalc_data()` to call `calc_backcalc_data()`
+  instead of `create_gp_data()`. By @jamesmbaazam in #388 and review by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/R/create.R
+++ b/R/create.R
@@ -268,21 +268,7 @@ create_rt_data <- function(rt = rt_opts(), breakpoints = NULL,
 #' @export
 #' @author Sam Abbott
 #' @examples
-#' # define input data required
-#' data <- list(
-#'   t = 30,
-#'   seeding_time = 7,
-#'   horizon = 7
-#' )
-#'
-#' # default gaussian process data
-#' create_gp_data(data = data)
-#'
-#' # settings when no gaussian process is desired
-#' create_gp_data(NULL, data)
-#'
-#' # custom lengthscale
-#' create_gp_data(gp_opts(ls_mean = 14), data)
+#' create_backcalc_data(backcalc = backcalc_opts())
 create_backcalc_data <- function(backcalc = backcalc_opts()) {
   data <- list(
    rt_half_window = as.integer((backcalc$rt_window - 1) / 2),

--- a/man/create_backcalc_data.Rd
+++ b/man/create_backcalc_data.Rd
@@ -19,21 +19,7 @@ Takes the output of \code{backcalc_opts()} and converts it into a list understoo
 by \code{stan}.
 }
 \examples{
-# define input data required
-data <- list(
-  t = 30,
-  seeding_time = 7,
-  horizon = 7
-)
-
-# default gaussian process data
-create_gp_data(data = data)
-
-# settings when no gaussian process is desired
-create_gp_data(NULL, data)
-
-# custom lengthscale
-create_gp_data(gp_opts(ls_mean = 14), data)
+create_backcalc_data(backcalc = backcalc_opts())
 }
 \seealso{
 backcalc_opts


### PR DESCRIPTION
This PR revises the previous example in `create_backcalc_data()` because it was calling `create_gp_data()` instead of `create_backcalc_data()`. 

This PR closes #385 