### PR TITLE
change the default value of sample in `dist_fit()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: EpiNow2
 Title: Estimate Real-Time Case Counts and Time-Varying
     Epidemiological Parameters
-Version: 1.3.6.6000
+Version: 1.3.6.7000
 Authors@R: 
     c(person(given = "Sam",
              family = "Abbott",

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,10 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
   instead of `create_gp_data()`. By @jamesmbaazam in #388 and reviewed by @seabbs.
 * Improved compilation times by reducing the number of distinct stan models and deprecated `tune_inv_gamma()`. By @sbfnk in #394 and reviewed by @seabbs.
 * Changed touchstone settings so that benchmarks are only performed if the stan model is changed. By @sbfnk in #400 and reviewed by @seabbs.
+* `dist_fit()`'s `samples` argument now takes a default value of 1000 instead
+  of NULL. If a supplied `samples` is less than 1000, it is changed to 1000
+  and a warning is thrown to indicate the change. By @jamesmbazam in #389 and
+  reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,10 +16,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
   instead of `create_gp_data()`. By @jamesmbaazam in #388 and reviewed by @seabbs.
 * Improved compilation times by reducing the number of distinct stan models and deprecated `tune_inv_gamma()`. By @sbfnk in #394 and reviewed by @seabbs.
 * Changed touchstone settings so that benchmarks are only performed if the stan model is changed. By @sbfnk in #400 and reviewed by @seabbs.
-* `dist_fit()`'s `samples` argument now takes a default value of 1000 instead
-  of NULL. If a supplied `samples` is less than 1000, it is changed to 1000
-  and a warning is thrown to indicate the change. By @jamesmbazam in #389 and
-  reviewed by @seabbs.
+* `dist_fit()`'s `samples` argument now takes a default value of 1000 instead of NULL. If a supplied `samples` is less than 1000, it is changed to 1000 and a warning is thrown to indicate the change. By @jamesmbazam in #389 and reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/R/dist.R
+++ b/R/dist.R
@@ -158,7 +158,8 @@ dist_skel <- function(n, dist = FALSE, cum = TRUE, model,
 #' `stan`.
 #' @param values Numeric vector of values
 #'
-#' @param samples Numeric, number of samples to take
+#' @param samples Numeric, number of samples to take. Must be >= 1000. 
+#' Defaults to 1000.
 #'
 #' @param dist Character string, which distribution to fit. Defaults to
 #' exponential (`"exp"`) but gamma (`"gamma"`) and lognormal (`"lognormal"`) are
@@ -197,16 +198,16 @@ dist_skel <- function(n, dist = FALSE, cum = TRUE, model,
 #'   cores = ifelse(interactive(), 4, 1), verbose = TRUE
 #' )
 #' }
-dist_fit <- function(values = NULL, samples = NULL, cores = 1,
+dist_fit <- function(values = NULL, samples = 1000, cores = 1,
                      chains = 2, dist = "exp", verbose = FALSE) {
-  if (is.null(samples)) {
-    samples <- 1000
-  }
-
   if (samples < 1000) {
     samples <- 1000
   }
 
+  warning(sprintf("%s %s", "`samples` must be at least 1000.",
+                  "Now setting it to 1000 internally."
+                  )
+          )
   # model parameters
   lows <- values - 1
   lows <- ifelse(lows <= 0, 1e-6, lows)

--- a/R/dist.R
+++ b/R/dist.R
@@ -202,12 +202,11 @@ dist_fit <- function(values = NULL, samples = 1000, cores = 1,
                      chains = 2, dist = "exp", verbose = FALSE) {
   if (samples < 1000) {
     samples <- 1000
+    warning(sprintf("%s %s", "`samples` must be at least 1000.",
+                    "Now setting it to 1000 internally."
+                    )
+            )
   }
-
-  warning(sprintf("%s %s", "`samples` must be at least 1000.",
-                  "Now setting it to 1000 internally."
-                  )
-          )
   # model parameters
   lows <- values - 1
   lows <- ifelse(lows <= 0, 1e-6, lows)

--- a/R/dist.R
+++ b/R/dist.R
@@ -158,7 +158,7 @@ dist_skel <- function(n, dist = FALSE, cum = TRUE, model,
 #' `stan`.
 #' @param values Numeric vector of values
 #'
-#' @param samples Numeric, number of samples to take. Must be >= 1000. 
+#' @param samples Numeric, number of samples to take. Must be >= 1000.
 #' Defaults to 1000.
 #'
 #' @param dist Character string, which distribution to fit. Defaults to

--- a/man/dist_fit.Rd
+++ b/man/dist_fit.Rd
@@ -6,7 +6,7 @@
 \usage{
 dist_fit(
   values = NULL,
-  samples = NULL,
+  samples = 1000,
   cores = 1,
   chains = 2,
   dist = "exp",
@@ -16,7 +16,8 @@ dist_fit(
 \arguments{
 \item{values}{Numeric vector of values}
 
-\item{samples}{Numeric, number of samples to take}
+\item{samples}{Numeric, number of samples to take. Must be >= 1000.
+Defaults to 1000.}
 
 \item{cores}{Numeric, defaults to 1. Number of CPU cores to use (no effect
 if greater than the number of chains).}


### PR DESCRIPTION
In the current design of `dist_fit()`, the argument `sample` is supplied with a default value of `NULL`, which is checked and replaced with 1000 if it's `NULL` or < 1000. I think that means it should have a default value of 1000 with a check to see if it's < 1000 when the default is overridden with a supplied value. 

In this PR, I change the default value of `samples` to 1000. If the value of `samples` is supplied, the function checks if `samples` is <1000, and if so, sets it to 1000 and throws a warning to inform the user. 