### PR TITLE
limit touchstone to stan model changes

### DIFF
--- a/.github/workflows/touchstone-receive.yaml
+++ b/.github/workflows/touchstone-receive.yaml
@@ -7,15 +7,11 @@ concurrency:
 on:
   pull_request:
     paths:
-      # Directories with source code and benchmarking code
-      - "inst/**"
-      - "R/**"
-      - "src/**"
+      # Directories with stan code and benchmarking code
+      - "inst/stan/**"
       - "touchstone/**"
       # Benchmarking config file
       - ".github/workflows/touchstone-*.yaml"
-      # Package metadata
-      - DESCRIPTION
 
 jobs:
   prepare:


### PR DESCRIPTION
Fixed #399.

We could add a manual trigger but I'm not sure we'd be able to see the results without being embedded in a PR.