### PR TITLE
Fix create_clean_reported_cases() error

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -24,7 +24,7 @@ create_clean_reported_cases <- function(reported_cases, horizon,
                                         zero_threshold = Inf) {
   reported_cases <- data.table::setDT(reported_cases)
   reported_cases_grid <- data.table::copy(reported_cases)[,
-   .(date = seq(min(date), max(date) + horizon, by = "days"))
+   .(date = seq(min(date), max(date) + horizon, by = 1))
   ]
 
   reported_cases <- data.table::merge.data.table(


### PR DESCRIPTION
This pull request aims to address an error I receive when using `estimate_infections()` which appears to be caused by the underlying `create_clean_reported_cases()` function.

Error message:

```
Error in seq.grates_period(min(date), max(date) + horizon, by = "days") : 
  `by` must be an integer of length 1.
```