### PR TITLE
Benchmarking skeleton

### DIFF
--- a/inst/dev/benchmark-functions.R
+++ b/inst/dev/benchmark-functions.R
@@ -1,0 +1,47 @@
+##' Create a benchmark profile
+##'
+##' This runs the `estimate_infections` function using a given stan model file
+##' multiple times with given seeds and extracts the `cmdstanr` profiling
+##' information each time.
+##' @param model name of a model file for estimating infections in `inst/stan`
+##' @param seeds a vector of random seeds to use; this determines how often
+##'   `estimate_infections` is run
+##' @return a data frame of profile informations, with the run id given as
+##'   `iter`
+create_profiles <- function(model, seeds = sample(.Machine$integer.max, 1)) {
+  compiled_model <- EpiNow2:::epinow2_model(model = model, force_recompile = TRUE)
+  profiles <- purrr::map(seeds, \(x) {
+    set.seed(x)
+    fit <- estimate_infections(
+      reported_cases = reported_cases,
+      generation_time = generation_time,
+      delays = delays,
+      rt = rt_opts(prior = list(mean = 2, sd = 0.2)),
+      stan = stan_opts(
+        samples = 1000, chains = 1, model_options = list(model = model)
+      )
+    )
+    return(fit$fit$profiles())
+  })
+  return(dplyr::bind_rows(profiles, .id = "iter"))
+}
+##' Calculate bootstrap mean and credible intervals
+##'
+##' Credible intervals are calculated from resampled quantiles
+##' @param x numeric vector
+##' @param n_boot number of bootstrap iterations
+##' @return a `tibble` with one row, containing the mean, 90% credible intervals
+##'  (`low`/`high`) and 99% credible intervals (`lower`/`higher`)
+bootci <- function(x, n_boot) {
+  m <- matrix(sample(x, n_boot * length(x), replace = TRUE), n_boot, length(x))
+  means <- apply(m, 1, mean)
+  return(list(tibble::tibble(
+    mean = mean(x), 
+    low = quantile(means, 0.05), 
+    high = quantile(means, 0.95),
+    lower = quantile(means, 0.005),
+    higher = quantile(means, 0.995)
+  )))
+}
+
+

--- a/inst/dev/benchmark.R
+++ b/inst/dev/benchmark.R
@@ -1,0 +1,37 @@
+devtools::load_all()
+library("dplyr")
+library("tibble")
+library("tidyr")
+library("here")
+
+## number of times to run estimate_infections
+n_iter <- 100
+## number of bootstrap replicates
+n_boot <- 100
+
+## random seeds
+seeds <- sample(.Machine$integer.max, n_iter)
+
+source(here::here("touchstone", "setup.R"))
+source(here::here("inst", "dev", "benchmark-functions.R"))
+
+profiles <- list()
+
+## generate profiles for different versions of the stan model
+profiles[["main"]] <- create_profiles("estimate_infections", seeds)
+
+## merge profiles from the two chains into one, round total time and only kep
+## name and total_time columns; then average across chains; sort by time from
+## longest to shortest
+summary <- profiles |>
+  dplyr::bind_rows(.id = "model") |>
+  # group by model and name
+  dplyr::group_by(model, name) %>%
+  # generate bootstrap samples and calculate mean and standard error for each 
+  # sample
+  dplyr::summarise(
+    bootstrap = bootci(total_time, n_boot = n_boot), .groups = "drop"
+  ) |>
+  tidyr::unnest(cols = c(bootstrap)) |>
+  dplyr::arrange(desc(mean))
+


### PR DESCRIPTION
This PR adds a skeleton of a script for benchmarking using the profiling functionality provided in `cmdstan` and targeting the `cmdstanr` branch. This supports addressing #412.

This only adds to `inst/dev` and doesn't affect any package functionality so can be merged without review I think. I have no intention to merge this into the main branch unless and until perhaps we address #48. 

Example output:

```{r}
> summary
# A tibble: 13 × 7
   model name                        mean         low       high   lower  higher
   <chr> <chr>                      <dbl>       <dbl>      <dbl>   <dbl>   <dbl>
 1 main  infections           8.18        7.93           8.39e+0 7.86e+0 8.53e+0
 2 main  report lp            7.49        7.24           7.76e+0 7.15e+0 7.83e+0
 3 main  reports              5.81        5.62           6.03e+0 5.53e+0 6.11e+0
 4 main  R                    4.32        4.16           4.47e+0 4.13e+0 4.50e+0
 5 main  update gp            3.91        3.77           4.06e+0 3.74e+0 4.09e+0
 6 main  day of the week      1.32        1.28           1.36e+0 1.27e+0 1.37e+0
 7 main  gt                   1.21        1.17           1.24e+0 1.16e+0 1.27e+0
 8 main  delays               0.638       0.617          6.53e-1 6.09e-1 6.67e-1
 9 main  rt lp                0.512       0.493          5.28e-1 4.89e-1 5.39e-1
10 main  gp lp                0.487       0.471          5.03e-1 4.64e-1 5.09e-1
11 main  delays lp            0.0729      0.0704         7.52e-2 6.96e-2 7.69e-2
12 main  generated quantities 0.0140      0.0140         1.41e-2 1.40e-2 1.41e-2
13 main  assign max           0.000000693 0.000000662    7.23e-7 6.46e-7 7.37e-7
```