### PR TITLE
update R CMD check action

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -18,6 +18,10 @@ on:
 
 name: R-CMD-check
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   R-CMD-check:
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
@@ -41,12 +45,7 @@ jobs:
       NOT_CRAN: true
       
     steps:
-      - uses: n1hility/cancel-previous-runs@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/main'"
-
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         
       - name: Install cmdstan Linux system dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
- bumps actions/checkout to the latest version (v3) closing #424
- replaces cancel-previous-runs with a concurrency group