### PR TITLE
fix logmean bound

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: EpiNow2
 Title: Estimate Real-Time Case Counts and Time-Varying
     Epidemiological Parameters
-Version: 1.3.6.9002
+Version: 1.3.6.9003
 Authors@R: 
     c(person(given = "Sam",
              family = "Abbott",

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -48,7 +48,7 @@ parameters{
   real<lower = 0> bp_sd[bp_n > 0 ? 1 : 0]; // standard deviation of breakpoint effect
   real bp_effects[bp_n];                   // Rt breakpoint effects
   // observation model
-  real<lower = 0> delay_mean[delay_n_p];         // mean of delays
+  real delay_mean[delay_n_p];         // mean of delays
   real<lower = 0> delay_sd[delay_n_p];  // sd of delays
   simplex[week_effect] day_of_week_simplex;// day of week reporting effect
   real<lower = 0, upper = 1> frac_obs[obs_scale];     // fraction of cases that are ultimately observed


### PR DESCRIPTION
https://github.com/epiforecasts/EpiNow2/commit/d0bea23c4d505f4478786790a6f040e3f30acfb4 introduced a bug where the logmean of delays is lower-bounded by 0 whereas it shouldn't be (for the gamma distribution this is done in the `delays_lp` function).