### PR TITLE
allow snapshots shorter than trunc_max

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 * Updated code style in response to lintr warnings. By @sbfnk in #437 and reviewed by @seabbs.
 * Fixed an edge case breaking summary output. Reported by @jrcpulliam, fixed by @sbfnk in #436 and reviewed by @seabbs.
 * Added content to the vignette for the estimate_truncation model. By @sbfnk in #439 and reviewed by @seabbs.
+* Fixed an issue in the `estimate_truncation` model where it threw an error when applied to time series that were shorter than the truncation max. By @sbfnk in #438 and reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 * Updated code style in response to lintr warnings. By @sbfnk in #437 and reviewed by @seabbs.
 * Fixed an edge case breaking summary output. Reported by @jrcpulliam, fixed by @sbfnk in #436 and reviewed by @seabbs.
 * Added content to the vignette for the estimate_truncation model. By @sbfnk in #439 and reviewed by @seabbs.
-* Fixed an issue in the `estimate_truncation` model where it threw an error when applied to time series that were shorter than the truncation max. By @sbfnk in #438 and reviewed by @seabbs.
+* Added a feature to the `estimate_truncation` to allow it to be applied to time series that are shorter than the truncation max. By @sbfnk in #438 and reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -151,7 +151,7 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
     confirm := NULL
   ])
   obs <- purrr::reduce(obs, merge, all = TRUE)
-  obs_start <- nrow(obs) - trunc_max - sum(is.na(obs$`1`)) + 1
+  obs_start <- max(nrow(obs) - trunc_max - sum(is.na(obs$`1`)) + 1, 1)
   obs_dist <- purrr::map_dbl(2:(ncol(obs)), ~ sum(is.na(obs[[.]])))
   obs_data <- obs[, -1][, purrr::map(.SD, ~ ifelse(is.na(.), 0, .))]
   obs_data <- obs_data[obs_start:.N]

--- a/inst/stan/estimate_truncation.stan
+++ b/inst/stan/estimate_truncation.stan
@@ -11,6 +11,14 @@ data {
   int trunc_max;
   int trunc_dist;
 }
+transformed data{
+  int<lower = 1> end_t[obs_sets];
+  int<lower = 1> start_t[obs_sets];
+  for (i in 1:obs_sets) {
+    end_t[i] = t - obs_dist[i];
+    start_t[i] = max(1, end_t[i] - trunc_max + 1);
+  }
+}
 parameters {
   real logmean;
   real<lower=0> logsd;
@@ -18,7 +26,8 @@ parameters {
   real<lower=0> sigma;
 }
 transformed parameters{
-  matrix[trunc_max, obs_sets - 1] trunc_obs;
+  matrix[trunc_max, obs_sets - 1] trunc_obs =
+    rep_matrix(0, trunc_max, obs_sets - 1);
   real sqrt_phi = 1 / sqrt(phi);
   vector[trunc_max] rev_cmf = reverse_mf(cumulative_sum(
     discretised_pmf(logmean, logsd, trunc_max, trunc_dist)
@@ -31,9 +40,8 @@ transformed parameters{
   // apply truncation to latest dataset to map back to previous data sets and
   // add noise term
   for (i in 1:(obs_sets - 1)) {
-   int end_t = t - obs_dist[i];
-   int start_t = end_t - trunc_max + 1;
-   trunc_obs[, i] = truncate(last_obs[start_t:end_t], rev_cmf, 0) + sigma;
+    trunc_obs[1:(end_t[i] - start_t[i] + 1), i] =
+      truncate(last_obs[start_t[i]:end_t[i]], rev_cmf, 0) + sigma;
    }
   }
 }
@@ -45,23 +53,28 @@ model {
   sigma ~ normal(0, 1) T[0,];
   // log density of truncated latest data vs that observed
   for (i in 1:(obs_sets - 1)) {
-    int start_t = t - obs_dist[i] - trunc_max;
-    for (j in 1:trunc_max) {
-      obs[start_t + j, i] ~ neg_binomial_2(trunc_obs[j, i], sqrt_phi);
+    for (j in 1:(end_t[i] - start_t[i] + 1)) {
+      obs[start_t[i] + j - 1, i] ~ neg_binomial_2(trunc_obs[j, i], sqrt_phi);
     }
   }
 }
 generated quantities {
-  matrix[trunc_max, obs_sets] recon_obs;
+  matrix[trunc_max, obs_sets] recon_obs = rep_matrix(0, trunc_max, obs_sets);
   matrix[trunc_max, obs_sets - 1] gen_obs;
   // reconstruct all truncated datasets using posterior of the truncation distribution
   for (i in 1:obs_sets) {
-    int end_t = t - obs_dist[i];
-    int start_t = end_t - trunc_max + 1;
-    recon_obs[, i] = truncate(to_vector(obs[start_t:end_t, i]), rev_cmf, 1);
+    recon_obs[1:(end_t[i] - start_t[i] + 1), i] = truncate(
+      to_vector(obs[start_t[i]:end_t[i], i]), rev_cmf, 1
+    );
   }
  // generate observations for comparing
   for (i in 1:(obs_sets - 1)) {
-    gen_obs[, i] = to_vector(neg_binomial_2_rng(trunc_obs[, i], sqrt_phi));
+    for (j in 1:trunc_max) {
+      if (trunc_obs[j, i] == 0) {
+        gen_obs[j, i] = 0;
+      } else {
+        gen_obs[j, i] = neg_binomial_2_rng(trunc_obs[j, i], sqrt_phi);
+      }
+    }
   }
 }

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -24,13 +24,13 @@ vector truncate(vector reports, vector trunc_rev_cmf, int reconstruct) {
   int t = num_elements(reports);
   vector[t] trunc_reports = reports;
   // Calculate cmf of truncation delay
-  int trunc_max = num_elements(trunc_rev_cmf);
+  int trunc_max = min(t, num_elements(trunc_rev_cmf));
   int first_t = t - trunc_max + 1;
   // Apply cdf of truncation delay to truncation max last entries in reports
   if (reconstruct) {
-    trunc_reports[first_t:t] = trunc_reports[first_t:t] ./ trunc_rev_cmf;
-  }else{
-    trunc_reports[first_t:t] = trunc_reports[first_t:t] .* trunc_rev_cmf;
+    trunc_reports[first_t:t] ./= trunc_rev_cmf[1:trunc_max];
+  } else {
+    trunc_reports[first_t:t] .*= trunc_rev_cmf[1:trunc_max];
   }
   return(trunc_reports);
 }


### PR DESCRIPTION
estimate_truncation currently fails when the any snapshot is shorter than `trunc_max`. This PR fixes that by provding explicit bounds and vector elements in the appropriate place.