### PR TITLE
update estimate truncation vignette

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 * Reduced verbosity of tests. By @sbfnk in #433 and reviewed by @seabbs.
 * Updated code style in response to lintr warnings. By @sbfnk in #437 and reviewed by @seabbs.
 * Fixed an edge case breaking summary output. Reported by @jrcpulliam, fixed by @sbfnk in #436 and reviewed by @seabbs.
+* Added content to the vignette for the estimate_truncation model. By @sbfnk in #439.
 
 # EpiNow2 1.3.5
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 * Reduced verbosity of tests. By @sbfnk in #433 and reviewed by @seabbs.
 * Updated code style in response to lintr warnings. By @sbfnk in #437 and reviewed by @seabbs.
 * Fixed an edge case breaking summary output. Reported by @jrcpulliam, fixed by @sbfnk in #436 and reviewed by @seabbs.
-* Added content to the vignette for the estimate_truncation model. By @sbfnk in #439.
+* Added content to the vignette for the estimate_truncation model. By @sbfnk in #439 and reviewed by @seabbs.
 
 # EpiNow2 1.3.5
 

--- a/vignettes/estimate_infections.Rmd
+++ b/vignettes/estimate_infections.Rmd
@@ -181,7 +181,7 @@ The scaling factor $\alpha$ represents the proportion of cases that are ultimate
 
 # Observation model
 
-The modelled cases $D_{t}$ are related to observations $C_{t}$.
+The modelled counts $D_{t}$ are related to observations $C_{t}$.
 By default this is assumed to follow a negative binomial distribution with overdispersion $\varphi$ (alternatively it can be modelled as a Poisson, in which case $\varphi$ is not used):
 
 \begin{align}
@@ -196,5 +196,15 @@ This model uses the following priors for the observation model,
     \frac{\omega}{n_\omega} &\sim \mathcal{Dirichlet}(1, \ldots, 1) \\
     \frac{1}{\sqrt{\varphi}} &\sim \mathcal{HalfNormal}(0, 1)
 \end{align}
+
+## Truncation
+
+The model supports counts that are right-truncated, i.e. reported with a delay leading to recent counts being subject to future upwards revision. Denoting the final truncated counts with $D^{\ast}_{t}$ they are obtained form the final modelled cases $D_{t}$ by applying a given discrete truncation distribution $\zeta(\tau | \mu_{\zeta}, \sigma_{\zeta})$ with cumulative mass function $\Zeta(\tau | \mu_{\zeta})$:
+
+\begin{equation}
+  D^ast_t = \Zeta (T - t | \mu_{\Zeta}, \sigma_{\Zeta}) D_{t}
+\end{equation}
+
+If truncation is applied, the modelled cases $D_{t}$ are replaced by the truncated counts before confronting them with observations $C_{t}$ as described above.
 
 # References

--- a/vignettes/estimate_truncation.Rmd
+++ b/vignettes/estimate_truncation.Rmd
@@ -17,7 +17,7 @@ knitr::opts_chunk$set(
 ```
 **This is a work in progress. Please consider submitting a PR to improve it.** 
 
-This model deals with the problem of _nowcasting_, or adjusting for right-truncation in reported count data. This occurs when the quantity being observed, for example cases, hospitalisations or deaths, is reported with a delay, resulting in an underestimation of recent counts. The `estimate_truncation()` model attempts to infer parameters of the underlying delay distributions from multiple snapshots of past data. It is designed as a simple and imperfect model. For a more principled approach to nowcasting please consider using the [epinowcast](https://package.epinowcast.org) package.
+This model deals with the problem of _nowcasting_, or adjusting for right-truncation in reported count data. This occurs when the quantity being observed, for example cases, hospitalisations or deaths, is reported with a delay, resulting in an underestimation of recent counts. The `estimate_truncation()` model attempts to infer parameters of the underlying delay distributions from multiple snapshots of past data. It is designed to be a simple model that can integrate with the other models in the package and therefore may not be ideal for all uses. For a more principled approach to nowcasting please consider using the [epinowcast](https://package.epinowcast.org) package.
 
 Given snapshots $C^{i}_{t}$ reflecting reported counts for time $t$ where $i=1\ldots S$ is in order of recency (earliest snapshots first) and $S$ is the number of past snapshots used for estimation, we try to infer the parameters of a discrete truncation distribution $\zeta(\tau | \mu_{\zeta}, \sigma_{\zeta})$ with corresponding probability mass function $\Zeta(\tau | \mu_{\zeta}$.
 

--- a/vignettes/estimate_truncation.Rmd
+++ b/vignettes/estimate_truncation.Rmd
@@ -16,3 +16,33 @@ knitr::opts_chunk$set(
 )
 ```
 **This is a work in progress. Please consider submitting a PR to improve it.** 
+
+This model deals with the problem of _nowcasting_, or adjusting for right-truncation in reported count data. This occurs when the quantity being observed, for example cases, hospitalisations or deaths, is reported with a delay, resulting in an underestimation of recent counts. The `estimate_truncation()` model attempts to infer parameters of the underlying delay distributions from multiple snapshots of past data. It is designed as a simple and imperfect model. For a more principled approach to nowcasting please consider using the [epinowcast](https://package.epinowcast.org) package.
+
+Given snapshots $C^{i}_{t}$ reflecting reported counts for time $t$ where $i=1\ldots S$ is in order of recency (earliest snapshots first) and $S$ is the number of past snapshots used for estimation, we try to infer the parameters of a discrete truncation distribution $\zeta(\tau | \mu_{\zeta}, \sigma_{\zeta})$ with corresponding probability mass function $\Zeta(\tau | \mu_{\zeta}$.
+
+The model assumes that final counts $D_{t}$ are related to observed snapshots via the truncation distribution such that
+
+\begin{equation}
+C^{i < S)_{t}_\sim \mathcal{NegBinom}\left(\Zeta (T_i - t | \mu_{\Zeta}, \sigma_{\Zeta}) D(t) + \sigma, \varphi\right)
+\end{equation}
+
+where $T_i$ is the date of the final observation in snapshot $i$, $\Zeta(\tau)$
+is defined to be zero for negative values of $\tau$ and $\sigma$ is an
+additional error term.
+
+The final counts $D_{t}$ are estimated from the most recent snapshot as
+
+\begin{equation}
+D_t = \frac{C^{S}}{\Zeta (T_\mathrm{S} - t | \mu_{\Zeta}, \sigma_{\Zeta})}
+\end{equation}
+
+Relevant priors are:
+
+\begin{align}
+\mu_\zeta &\sim \mathrm{Normal}(0, 1)\\
+\sigma_\zeta &\sim \mathrm{HalfNormal}(0, 1)\\
+\varphi &\sim \mathrm{HalfNormal}(0, 1)\\
+\sigma &\sim \mathrm{HalfNormal}(0, 1)
+\end{align}
+


### PR DESCRIPTION
Adds some content to the `estimate_truncation` vignette and updates the `estimate_infections` vignette to match it.