### PR TITLE
Issue 440: Added CSTE workshop as a case study

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: EpiNow2
 Title: Estimate Real-Time Case Counts and Time-Varying
     Epidemiological Parameters
-Version: 1.3.6.9005
+Version: 1.3.6.9006
 Authors@R: 
     c(person(given = "Sam",
              family = "Abbott",

--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,10 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 * Added content to the vignette for the estimate_truncation model. By @sbfnk in #439 and reviewed by @seabbs.
 * Added a feature to the `estimate_truncation` to allow it to be applied to time series that are shorter than the truncation max. By @sbfnk in #438 and reviewed by @seabbs.
 
+## Documentation
+
+- Added a link to the recent CSTE workshop on using `EpiNow2` to the case studies vignette. By @seabbs in #441 and reviewed by @sbfnk.
+
 # EpiNow2 1.3.5
 
 This is a minor release to resolve issues with the recent CRAN requirement to make use of a C++ 17 compiler which has been causing [issues with the `rstantools` package](https://github.com/stan-dev/rstantools/pull/100).

--- a/vignettes/case-studies.Rmd
+++ b/vignettes/case-studies.Rmd
@@ -18,6 +18,7 @@ knitr::opts_chunk$set(
 
 # Case studies 
 
+- [Estimating reporting delays and nowcasting/forecasting infections with EpiNow2 using HHS COVID-19 hospitalizations](https://samabbott.co.uk/cste-forecasting-workshop/)
 - [Estimating reporting delays and nowcasting/forecasting infections with EpiNow2](https://github.com/epiforecasts/nowcasting.example/blob/main/inst/reports/epinow2.md) by Sebastian Funk and Sam Abbott.
 - [Forecast Covid-19 reported deaths from Covid-19 reported cases (both observed and forecast) for a country in the ECDC](https://gist.github.com/seabbs/4f09d7609df298db7a86c31612ff9d17) by Sam Abbott.
 - [Explore Covid-19 data truncation in England](https://gist.github.com/seabbs/176b0c7f83eab1a7192a25b28bbd116a) by Sam Abbott.


### PR DESCRIPTION
This PR adds the recent CSTE workshop resource as a case study linked from the vignette. It closes #440.