### PR TITLE
Improve deprecation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ This release is in development. For a stable release install 1.3.5 from CRAN.
 
 ## Breaking changes
 
-- The external distribution interface has been updated to use the `dist_spec()` function. This comes with a range of benefits, including optimising model fitting when static delays are used (by convolving when first defined vs in stan), easy printing (using `print()`), and easy plotting (using `plot()`). It also makes it possible to use all supported distributions everywhere (i.e, as a generation time or reporting delay). However, this update will break most users code as the interface has changed. See the documentation for `dist_spec()` for more details. By @sbfnk in #363 and reviewed by @seabbs.
+- The external distribution interface has been updated to use the `dist_spec()` function. This comes with a range of benefits, including optimising model fitting when static delays are used (by convolving when first defined vs in stan), easy printing (using `print()`), and easy plotting (using `plot()`). It also makes it possible to use all supported distributions everywhere (i.e, as a generation time or reporting delay). However, while for now backwards compatibility has been ensured this update will break most users' code eventually as the interface has changed. See the documentation for `dist_spec()` for more details. By @sbfnk in #363 and reviewed by @seabbs.
 
 ## Package
 

--- a/R/dist.R
+++ b/R/dist.R
@@ -817,7 +817,7 @@ sample_approx_dist <- function(cases = NULL,
 #'
 tune_inv_gamma <- function(lower = 2, upper = 21) {
   lifecycle::deprecate_stop(
-    "1.3.6", "tune_inv_gamma()",
+    "1.4.0", "tune_inv_gamma()",
     details = paste0(
       "As no inverse gamma priors are currently in use and this function has ",
       "some stability issues it has been deprecated. Please let the package ",

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -162,9 +162,11 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
         "`max_truncation` and `trunc_max` arguments are both given. ",
         "Use only `truncation` instead.")
     }
-    warning(
-      "The `trunc_max` argument is deprecated and will be removed in ",
-      "version 2.0.0. Use `truncation` instead."
+    deprecate_warn(
+      "1.4.0",
+      "estimate_truncation(trunc_max)",
+      "estimate_truncation(truncation)",
+      "The argument will be removed completely in version 2.0.0."
     )
     construct_trunc <- TRUE
   }
@@ -174,9 +176,11 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
         "`max_truncation` and `truncation` arguments are both given. ",
         "Use only `truncation` instead.")
     }
-    warning(
-      "The `max_truncation` argument is deprecated and will be removed in ",
-      "version 2.0.0. Use `truncation` instead."
+    deprecate_warn(
+      "1.4.0",
+      "estimate_truncation(max_truncation)",
+      "estimate_truncation(truncation)",
+      "The argument will be removed completely in version 2.0.0."
     )
     trunc_max <- max_truncation
     construct_trunc <- TRUE
@@ -188,9 +192,11 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
         "`trunc_dist` and `truncation` arguments are both given. ",
         "Use only `truncation` instead.")
     }
-     warning(
-      "The `trunc_dist` argument is deprecated and will be removed in ",
-      "version 2.0.0. Use `truncation` instead."
+    deprecate_warn(
+      "1.4.0",
+      "estimate_truncation(trunc_dist)",
+      "estimate_truncation(truncation)",
+      "The argument will be removed completely in version 2.0.0."
     )
     construct_trunc <- TRUE
   }

--- a/man/delay_opts.Rd
+++ b/man/delay_opts.Rd
@@ -4,11 +4,15 @@
 \alias{delay_opts}
 \title{Delay Distribution Options}
 \usage{
-delay_opts(dist = dist_spec())
+delay_opts(dist = dist_spec(), ..., fixed = FALSE)
 }
 \arguments{
 \item{dist}{A delay distribution or series of delay distributions generated
 using \code{\link[=dist_spec]{dist_spec()}}. Default is an empty call to \code{\link[=dist_spec]{dist_spec()}}, i.e. no delay}
+
+\item{...}{deprecated; use \code{dist} instead}
+
+\item{fixed}{deprecated; use \code{dist} instead}
 }
 \value{
 A list summarising the input delay distributions.

--- a/man/generation_time_opts.Rd
+++ b/man/generation_time_opts.Rd
@@ -4,12 +4,34 @@
 \alias{generation_time_opts}
 \title{Generation Time Distribution Options}
 \usage{
-generation_time_opts(dist = dist_spec(mean = 1))
+generation_time_opts(
+  dist = dist_spec(mean = 1),
+  ...,
+  disease,
+  source,
+  max = 15L,
+  fixed = FALSE,
+  prior_weight
+)
 }
 \arguments{
 \item{dist}{A delay distribution or series of delay distributions generated
 using \code{\link[=dist_spec]{dist_spec()}} or \code{\link[=get_generation_time]{get_generation_time()}}. If no distribution is given
 a fixed generation time of 1 will be assumed.}
+
+\item{...}{deprecated; use \code{dist} instead}
+
+\item{disease}{deprecated; use \code{dist} instead}
+
+\item{source}{deprecated; use \code{dist} instead}
+
+\item{max}{deprecated; use \code{dist} instead}
+
+\item{fixed}{deprecated; use \code{dist} instead}
+
+\item{prior_weight}{deprecated; prior weights are now specified as a
+model option. Use the \code{weigh_delay_priors} argument of \code{estimate_infections}
+instead.}
 }
 \value{
 A list summarising the input delay distributions.

--- a/tests/testthat/test-delays.R
+++ b/tests/testthat/test-delays.R
@@ -104,3 +104,36 @@ test_that("contradictory delays are caught", {
     "must be 0"
   )
 })
+
+test_that("deprecated arguments are caught", {
+  expect_warning(
+    test_stan_delays(
+      generation_time = generation_time_opts(mean = 3),
+      params = delay_params
+    ), "deprecated"
+  )
+  expect_error(
+    test_stan_delays(
+      delays = delay_opts(mean = 3),
+      params = delay_params
+    ), "named arguments"
+  )
+  expect_warning(
+    test_stan_delays(
+      delays = delay_opts(list(mean = 3)),
+      params = delay_params
+    ), "deprecated"
+  )
+  expect_warning(
+    test_stan_delays(
+      delays = delay_opts(list(mean = 3)),
+      params = delay_params
+    ), "deprecated"
+  )
+  expect_warning(
+    test_stan_delays(
+      delays = trunc_opts(list(mean = 3)),
+      params = delay_params
+    ), "deprecated"
+  )
+})


### PR DESCRIPTION
Adds soft deprecation for the old distribution interface so as to avoid nasty surprises for unsuspecting CRAN users.

This is in anticipation of a 1.4.0 CRAN release.