### PR TITLE
testing with updated rstan

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -144,6 +144,7 @@ LinkingTo:
     StanHeaders (>= 2.26.0)
 Remotes:
     stan-dev/rstan/rstan/rstan@develop
+    stan-dev/rstan/StanHeaders@develop
 Biarch: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -143,7 +143,7 @@ LinkingTo:
     rstan (>= 2.26.0),
     StanHeaders (>= 2.26.0)
 Remotes:
-    stan-dev/rstan/rstan/rstan@develop
+    stan-dev/rstan/rstan/rstan@develop,
     stan-dev/rstan/StanHeaders@develop
 Biarch: true
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -143,7 +143,7 @@ LinkingTo:
     rstan (>= 2.26.0),
     StanHeaders (>= 2.26.0)
 Remotes:
-    stan-dev/rstan/StanHeaders@develop,
+    StanHeaders=github::stan-dev/rstan/StanHeaders@develop,
     stan-dev/rstan/rstan/rstan@develop
 Biarch: true
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,7 +113,7 @@ Imports:
     R.utils (>= 2.0.0),
     Rcpp (>= 0.12.0), 
     rlang (>= 0.4.7),
-    rstan (>= d962b4cd960d1a10c5ce0bbf0d442648159bdcd1),
+    rstan,
     rstantools (>= 2.2.0),
     runner,
     scales,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -118,7 +118,6 @@ Imports:
     runner,
     scales,
     stats,
-    StanHeaders,
     truncnorm,
     utils
 Suggests:
@@ -144,8 +143,8 @@ LinkingTo:
     rstan (>= 2.26.0),
     StanHeaders (>= 2.26.0)
 Remotes:
-    stan-dev/rstan/rstan/rstan@develop,
-    stan-dev/rstan/StanHeaders@develop
+    stan-dev/rstan/StanHeaders@develop,
+    stan-dev/rstan/rstan/rstan@develop
 Biarch: true
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -118,6 +118,7 @@ Imports:
     runner,
     scales,
     stats,
+    StanHeaders,
     truncnorm,
     utils
 Suggests:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,7 +113,7 @@ Imports:
     R.utils (>= 2.0.0),
     Rcpp (>= 0.12.0), 
     rlang (>= 0.4.7),
-    rstan (>= 2.26.0),
+    rstan (>= d962b4cd960d1a10c5ce0bbf0d442648159bdcd1),
     rstantools (>= 2.2.0),
     runner,
     scales,
@@ -142,6 +142,8 @@ LinkingTo:
     RcppParallel (>= 5.0.1),
     rstan (>= 2.26.0),
     StanHeaders (>= 2.26.0)
+Remotes:
+    stan-dev/rstan/rstan/rstan@develop
 Biarch: true
 Config/testthat/edition: 3
 Encoding: UTF-8


### PR DESCRIPTION
can't use this for any CRAN version but could be an intermediate solution for getting all the tests/checks up and running again