### PR TITLE
Fix partial matching

### DIFF
--- a/R/create.R
+++ b/R/create.R
@@ -156,15 +156,16 @@ create_shifted_cases <- function(reported_cases, shift,
 #' time.
 #'
 #' @param delay Numeric mean delay
-#'
+#' 
+#' @importFrom rlang arg_match
 #' @return A list containing a logical called fixed and an integer called from
 #' @author Sam Abbott
 create_future_rt <- function(future = "latest", delay = 0) {
   out <- list(fixed = FALSE, from = 0)
   if (is.character(future)) {
-    future <- match.arg(
+    future <- arg_match(
       future,
-      c(
+      values = c(
         "project",
         "latest",
         "estimate"

--- a/R/create.R
+++ b/R/create.R
@@ -156,7 +156,6 @@ create_shifted_cases <- function(reported_cases, shift,
 #' time.
 #'
 #' @param delay Numeric mean delay
-#' 
 #' @importFrom rlang arg_match
 #' @return A list containing a logical called fixed and an integer called from
 #' @author Sam Abbott

--- a/R/dist.R
+++ b/R/dist.R
@@ -892,7 +892,7 @@ tune_inv_gamma <- function(lower = 2, upper = 21) {
 #'
 #' @author Sebastian Funk
 #' @author Sam Abbott
-#' @importFrom rlang warn
+#' @importFrom rlang warn arg_match
 #' @export
 #' @examples
 #' # A fixed lognormal distribution with mean 5 and sd 1.
@@ -973,7 +973,7 @@ dist_spec <- function(mean, sd = 0, mean_sd = 0, sd_sd = 0,
     }
   }
 
-  distribution <- match.arg(distribution)
+  distribution <- arg_match(distribution)
   if (fixed) {
     ret <- list(
       mean_mean = numeric(0),
@@ -1392,11 +1392,12 @@ plot.dist_spec <- function(x, ...) {
 ##'   mean and standard deviation) or "sample" (randomly sample mean and
 ##'   standard deviation from uncertainty given in the `dist_spec`)
 ##' @importFrom truncnorm rtruncnorm
+##' @importFrom rlang arg_match
 fix_dist <- function(x, strategy = c("mean", "sample")) {
   ## if x is fixed already we don't have to do anything
   if (x$fixed) return(x)
   ## match startegy argument to options
-  strategy <- match.arg(strategy)
+  strategy <- arg_match(strategy)
   ## apply stragey depending on choice
   if (strategy == "mean") {
     x <- dist_spec(

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -251,7 +251,8 @@ estimate_secondary <- function(reports,
 #'
 #' @param ... Overwrite options defined by type. See the returned values for all
 #' options that can be passed.
-#'
+#' 
+#' @importFrom rlang arg_match
 #' @seealso estimate_secondary
 #' @return A `<secondary_opts>` object of binary options summarising secondary
 #' model used in `estimate_secondary()`. Options returned are `cumulative`
@@ -272,8 +273,11 @@ estimate_secondary <- function(reports,
 #' # prevalence model
 #' secondary_opts("prevalence")
 secondary_opts <- function(type = "incidence", ...) {
-  type <- match.arg(type, choices = c("incidence", "prevalence"))
-  if (type == "incidence") {
+  type <- arg_match(
+    type,
+    values = c("incidence", "prevalence")
+  )
+  if (type %in% "incidence") {
     data <- list(
       cumulative = 0,
       historic = 1,
@@ -463,6 +467,7 @@ plot.estimate_secondary <- function(x, primary = FALSE,
 #' @inheritParams secondary_opts
 #' @importFrom data.table as.data.table copy shift
 #' @importFrom purrr pmap_dbl
+#' @importFrom rlang arg_match
 #' @export
 #' @examples
 #' # load data.table for manipulation
@@ -500,8 +505,8 @@ plot.estimate_secondary <- function(x, primary = FALSE,
 #' cases
 simulate_secondary <- function(data, type = "incidence", family = "poisson",
                                delay_max = 30, ...) {
-  type <- match.arg(type, choices = c("incidence", "prevalence"))
-  family <- match.arg(family, choices = c("none", "poisson", "negbin"))
+  type <- arg_match(type, values = c("incidence", "prevalence"))
+  family <- arg_match(family, values = c("none", "poisson", "negbin"))
   data <- data.table::as.data.table(data)
   data <- data.table::copy(data)
   data <- data[, index := seq_len(.N)]

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -251,7 +251,6 @@ estimate_secondary <- function(reports,
 #'
 #' @param ... Overwrite options defined by type. See the returned values for all
 #' options that can be passed.
-#' 
 #' @importFrom rlang arg_match
 #' @seealso estimate_secondary
 #' @return A `<secondary_opts>` object of binary options summarising secondary

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -276,7 +276,7 @@ secondary_opts <- function(type = "incidence", ...) {
     type,
     values = c("incidence", "prevalence")
   )
-  if (type %in% "incidence") {
+  if (type == "incidence") {
     data <- list(
       cumulative = 0,
       historic = 1,

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -75,6 +75,7 @@
 #' @importFrom rstan sampling
 #' @importFrom data.table copy .N as.data.table merge.data.table setDT
 #' @importFrom data.table setcolorder
+#' @importFrom rlang arg_match
 #' @importFrom checkmate assert_character assert_numeric assert_class
 #' assert_logical
 #' @examples
@@ -195,7 +196,7 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
     construct_trunc <- TRUE
   }
   if (!missing(trunc_dist)) {
-    trunc_dist <- match.arg(trunc_dist)
+    trunc_dist <- arg_match(trunc_dist)
     if (!missing(truncation)) {
       stop(
         "`trunc_dist` and `truncation` arguments are both given. ",

--- a/R/opts.R
+++ b/R/opts.R
@@ -448,7 +448,6 @@ gp_opts <- function(basis_prop = 0.2,
 #'
 #' @param return_likelihood Logical, defaults to `FALSE`. Should the likelihood
 #' be returned by the model.
-#' 
 #' @importFrom rlang arg_match
 #'
 #' @return An `<obs_opts>` object of observation model settings.
@@ -619,7 +618,6 @@ rstan_vb_opts <- function(samples = 2000,
 #' `rstan::sampling` ("sampling") or `rstan:vb` ("vb").
 #'
 #' @param ... Additional parameters to pass  underlying option functions.
-#' 
 #' @importFrom rlang arg_match
 #' @return A list of arguments to pass to the appropriate rstan functions.
 #' @author Sam Abbott

--- a/R/opts.R
+++ b/R/opts.R
@@ -313,7 +313,6 @@ rt_opts <- function(prior = list(mean = 1, sd = 1),
 #' @param rt_window Integer, defaults to 1. The size of the centred rolling
 #' average to use when estimating Rt. This must be odd so that the central
 #' estimate is included.
-#' 
 #' @importFrom rlang arg_match
 #'
 #' @return A `<backcalc_opts>` object of back calculation settings.
@@ -622,7 +621,6 @@ rstan_vb_opts <- function(samples = 2000,
 #' @param ... Additional parameters to pass  underlying option functions.
 #' 
 #' @importFrom rlang arg_match
-#'
 #' @return A list of arguments to pass to the appropriate rstan functions.
 #' @author Sam Abbott
 #' @export

--- a/R/opts.R
+++ b/R/opts.R
@@ -52,7 +52,7 @@ generation_time_opts <- function(dist = dist_spec(mean = 1), ...,
   }
   if (length(dot_options) > 0) {
     if (is(dist, "dist_spec")) { ## dist not specified
-      dot_options$dist <- "gamma"
+      dot_options$distribution <- "gamma"
     }
     ## set max
     if (!("max" %in% names(dot_options))) {
@@ -398,7 +398,7 @@ gp_opts <- function(basis_prop = 0.2,
                     ls_min = 0,
                     ls_max = 60,
                     alpha_sd = 0.05,
-                    kernel = "matern",
+                    kernel = "matern_3/2",
                     matern_type = 3 / 2) {
   gp <- list(
     basis_prop = basis_prop,

--- a/R/opts.R
+++ b/R/opts.R
@@ -246,6 +246,7 @@ trunc_opts <- function(dist = dist_spec()) {
 #' reproduction number.
 #' @author Sam Abbott
 #' @inheritParams create_future_rt
+#' @importFrom rlang arg_match
 #' @export
 #' @examples
 #' # default settings
@@ -270,7 +271,7 @@ rt_opts <- function(prior = list(mean = 1, sd = 1),
     use_breakpoints = use_breakpoints,
     future = future,
     pop = pop,
-    gp_on = match.arg(gp_on, choices = c("R_t-1", "R0"))
+    gp_on = arg_match(gp_on, values = c("R_t-1", "R0"))
   )
 
   # replace default settings with those specified by user
@@ -312,6 +313,8 @@ rt_opts <- function(prior = list(mean = 1, sd = 1),
 #' @param rt_window Integer, defaults to 1. The size of the centred rolling
 #' average to use when estimating Rt. This must be odd so that the central
 #' estimate is included.
+#' 
+#' @importFrom rlang arg_match
 #'
 #' @return A `<backcalc_opts>` object of back calculation settings.
 #' @author Sam Abbott
@@ -321,7 +324,7 @@ rt_opts <- function(prior = list(mean = 1, sd = 1),
 #' backcalc_opts()
 backcalc_opts <- function(prior = "reports", prior_window = 14, rt_window = 1) {
   backcalc <- list(
-    prior = match.arg(prior, choices = c("reports", "none", "infections")),
+    prior = arg_match(prior, values = c("reports", "none", "infections")),
     prior_window = prior_window,
     rt_window = as.integer(rt_window)
   )
@@ -378,6 +381,7 @@ backcalc_opts <- function(prior = "reports", prior_window = 14, rt_window = 1) {
 #' approximate Gaussian process. See (Riutort-Mayol et al. 2020
 #' <https://arxiv.org/abs/2004.11408>) for advice on updating this default.
 #'
+#' @importFrom rlang arg_match
 #' @return A `<gp_opts>` object of settings defining the Gaussian process
 #' @author Sam Abbott
 #' @export
@@ -404,7 +408,7 @@ gp_opts <- function(basis_prop = 0.2,
     ls_min = ls_min,
     ls_max = ls_max,
     alpha_sd = alpha_sd,
-    kernel = match.arg(kernel, choices = c("se", "matern_3/2")),
+    kernel = arg_match(kernel, values = c("se", "matern_3/2")),
     matern_type = matern_type
   )
 
@@ -445,6 +449,8 @@ gp_opts <- function(basis_prop = 0.2,
 #'
 #' @param return_likelihood Logical, defaults to `FALSE`. Should the likelihood
 #' be returned by the model.
+#' 
+#' @importFrom rlang arg_match
 #'
 #' @return An `<obs_opts>` object of observation model settings.
 #' @author Sam Abbott
@@ -470,7 +476,7 @@ obs_opts <- function(family = "negbin",
     stop("phi be numeric and of length two")
   }
   obs <- list(
-    family = match.arg(family, choices = c("poisson", "negbin")),
+    family = arg_match(family, values = c("poisson", "negbin")),
     phi = phi,
     weight = weight,
     week_effect = week_effect,
@@ -614,6 +620,8 @@ rstan_vb_opts <- function(samples = 2000,
 #' `rstan::sampling` ("sampling") or `rstan:vb` ("vb").
 #'
 #' @param ... Additional parameters to pass  underlying option functions.
+#' 
+#' @importFrom rlang arg_match
 #'
 #' @return A list of arguments to pass to the appropriate rstan functions.
 #' @author Sam Abbott
@@ -628,7 +636,7 @@ rstan_vb_opts <- function(samples = 2000,
 rstan_opts <- function(object = NULL,
                        samples = 2000,
                        method = "sampling", ...) {
-  method <- match.arg(method, choices = c("sampling", "vb"))
+  method <- arg_match(method, values = c("sampling", "vb"))
   # shared everywhere opts
   if (is.null(object)) {
     object <- stanmodels$estimate_infections
@@ -673,6 +681,7 @@ rstan_opts <- function(object = NULL,
 #'
 #' @param ... Additional parameters to pass  underlying option functions.
 #'
+#' @importFrom rlang arg_match
 #' @return A `<stan_opts>` object  of arguments to pass to the appropriate
 #' rstan functions.
 #' @author Sam Abbott
@@ -690,8 +699,8 @@ stan_opts <- function(samples = 2000,
                       init_fit = NULL,
                       return_fit = TRUE,
                       ...) {
-  backend <- match.arg(backend, choices = "rstan")
-  if (backend == "rstan") {
+  backend <- arg_match(backend, values = "rstan")
+  if (backend %in% "rstan") {
     opts <- rstan_opts(
       samples = samples,
       ...
@@ -699,7 +708,7 @@ stan_opts <- function(samples = 2000,
   }
   if (!is.null(init_fit)) {
     if (is.character(init_fit)) {
-      init_fit <- match.arg(init_fit, choices = "cumulative")
+      init_fit <- arg_match(init_fit, values = "cumulative")
     }
     opts$init_fit <- init_fit
   }

--- a/R/opts.R
+++ b/R/opts.R
@@ -696,7 +696,7 @@ stan_opts <- function(samples = 2000,
                       return_fit = TRUE,
                       ...) {
   backend <- arg_match(backend, values = "rstan")
-  if (backend %in% "rstan") {
+  if (backend == "rstan") {
     opts <- rstan_opts(
       samples = samples,
       ...

--- a/R/plot.R
+++ b/R/plot.R
@@ -78,6 +78,7 @@ plot_CrIs <- function(plot, CrIs, alpha, linewidth) {
 #' @importFrom scales comma
 #' @importFrom data.table setDT fifelse copy as.data.table
 #' @importFrom purrr map
+#' @importFrom rlang arg_match
 #' @examples
 #' # get example model results
 #' out <- readRDS(system.file(
@@ -129,10 +130,10 @@ plot_estimates <- function(estimate, reported, ylab = "Cases", hline,
 
   orig_estimate <- copy(estimate)
   if (!is.null(estimate_type)) {
-    estimate_type <- match.arg(
+    estimate_type <- arg_match(
       estimate_type,
-      choices = c("Estimate", "Estimate based on partial data", "Forecast"),
-      several.ok = TRUE
+      values = c("Estimate", "Estimate based on partial data", "Forecast"),
+      multiple = TRUE
     )
     estimate <- estimate[type %in% estimate_type]
   }
@@ -374,6 +375,8 @@ plot_summary <- function(summary_results,
 #' "R", "growth_rate", "summary", "all".
 #'
 #' @param ... Pass additional arguments to report_plots
+#' 
+#' @importFrom rlang arg_match
 #'
 #' @seealso plot report_plots estimate_infections
 #' @aliases plot
@@ -386,7 +389,7 @@ plot.estimate_infections <- function(x, type = "summary", ...) {
     reported = x$observations, ...
   )
   choices <- c("infections", "reports", "R", "growth_rate", "summary", "all")
-  type <- match.arg(type, choices, several.ok = TRUE)
+  type <- arg_match(type, values = choices, multiple = TRUE)
   if (type %in% "all") {
     type <- choices[-length(choices)]
   }

--- a/R/plot.R
+++ b/R/plot.R
@@ -306,7 +306,7 @@ plot_summary <- function(summary_results,
   upper_CrI <- paste0("upper_", max_CrI) # nolint
   max_upper <- max(
     summary_results[
-      metric %in% "New confirmed cases by infection date"][, ..upper_CrI],
+      metric == "New confirmed cases by infection date"][, ..upper_CrI],
       na.rm = TRUE
   )
   max_cases <- min(
@@ -319,7 +319,7 @@ plot_summary <- function(summary_results,
   # cases plot
   cases_plot <-
     inner_plot(
-      summary_results[metric %in% "New confirmed cases by infection date"]
+      summary_results[metric == "New confirmed cases by infection date"]
     ) +
     ggplot2::labs(x = x_lab, y = "") +
     ggplot2::expand_limits(y = 0) +
@@ -346,7 +346,7 @@ plot_summary <- function(summary_results,
   }
 
   # rt plot
-  rt_data <- summary_results[metric %in% "Effective reproduction no."]
+  rt_data <- summary_results[metric == "Effective reproduction no."]
   uppers <- grepl("upper_", colnames(rt_data), fixed = TRUE) # nolint
   max_rt <- max(data.table::copy(rt_data)[, ..uppers], na.rm = TRUE)
   rt_plot <-
@@ -389,7 +389,7 @@ plot.estimate_infections <- function(x, type = "summary", ...) {
   )
   choices <- c("infections", "reports", "R", "growth_rate", "summary", "all")
   type <- arg_match(type, values = choices, multiple = TRUE)
-  if (type %in% "all") {
+  if (type == "all") {
     type <- choices[-length(choices)]
   }
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -294,11 +294,11 @@ plot_summary <- function(summary_results,
       ggplot2::facet_wrap(~metric, ncol = 1, scales = "free_y") +
       ggplot2::theme_bw() +
       ggplot2::scale_color_manual(values = c(
-        "Increasing" = "#e75f00",
+        Increasing = "#e75f00",
         "Likely increasing" = "#fd9e49",
         "Likely decreasing" = "#5fa2ce",
-        "Decreasing" = "#1170aa",
-        "Stable" = "#7b848f"
+        Decreasing = "#1170aa",
+        Stable = "#7b848f"
       ), drop = FALSE)
   }
 

--- a/R/plot.R
+++ b/R/plot.R
@@ -375,7 +375,6 @@ plot_summary <- function(summary_results,
 #' "R", "growth_rate", "summary", "all".
 #'
 #' @param ... Pass additional arguments to report_plots
-#' 
 #' @importFrom rlang arg_match
 #'
 #' @seealso plot report_plots estimate_infections

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -538,15 +538,14 @@ regional_runtimes <- function(regional_output = NULL,
     regions <- get_regions(target_folder)
     timings <- data.table::data.table(
       region = regions,
-      time = unlist(purrr::map(regions, ~ safe_read(paste0(
-        target_folder,
-        "/", ., "/", target_date,
-        "/runtime.rds"
+      time = unlist(purrr::map(regions, ~ safe_read(file.path(
+        target_folder,., target_date,
+        "runtime.rds"
       )))[[1]])
     )
   }
   if (!is.null(target_folder)) {
-    data.table::fwrite(timings, paste0(target_folder, "/runtimes.csv"))
+    data.table::fwrite(timings, file.path(target_folder, "runtimes.csv"))
   }
   if (return_output) {
     return(timings)

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -794,7 +794,6 @@ summary.epinow <- function(object, output = "estimates",
 #' @param params A character vector of parameters to filter for.
 #'
 #' @param ... Pass additional arguments to `report_summary`
-#' 
 #' @importFrom rlang arg_match
 #' @seealso summary estimate_infections report_summary
 #' @method summary estimate_infections

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -539,7 +539,7 @@ regional_runtimes <- function(regional_output = NULL,
     timings <- data.table::data.table(
       region = regions,
       time = unlist(purrr::map(regions, ~ safe_read(file.path(
-        target_folder,., target_date,
+        target_folder, ., target_date,
         "runtime.rds"
       )))[[1]])
     )

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -742,6 +742,8 @@ calc_summary_measures <- function(samples,
 #'
 #' @inheritParams summary.estimate_infections
 #'
+#' @importFrom rlang arg_match
+#'
 #' @param ... Pass additional summary arguments to lower level methods
 #'
 #' @seealso summary.estimate_infections epinow
@@ -753,7 +755,7 @@ summary.epinow <- function(object, output = "estimates",
                            date = NULL, params = NULL,
                            ...) {
   choices <- c("estimates", "forecast", "estimated_reported_cases")
-  output <- match.arg(output, choices, several.ok = FALSE)
+  output <- arg_match(output, values = choices, multiple = FALSE)
   if (output %in% "estimates") {
     out <- summary(object$estimates,
       date = date,
@@ -792,7 +794,8 @@ summary.epinow <- function(object, output = "estimates",
 #' @param params A character vector of parameters to filter for.
 #'
 #' @param ... Pass additional arguments to `report_summary`
-#'
+#' 
+#' @importFrom rlang arg_match
 #' @seealso summary estimate_infections report_summary
 #' @method summary estimate_infections
 #' @return Returns a data frame of summary output
@@ -800,7 +803,7 @@ summary.epinow <- function(object, output = "estimates",
 summary.estimate_infections <- function(object, type = "snapshot",
                                         date = NULL, params = NULL, ...) {
   choices <- c("snapshot", "parameters", "samples")
-  type <- match.arg(type, choices, several.ok = FALSE)
+  type <- arg_match(type, values = choices, multiple = FALSE)
   if (is.null(date)) {
     target_date <- unique(
       object$summarised[type != "forecast"][date == max(date)]$date

--- a/R/summarise.R
+++ b/R/summarise.R
@@ -90,7 +90,7 @@ summarise_results <- function(regions,
 
 
   numeric_estimates <- data.table::merge.data.table(numeric_estimates,
-    estimates[measure %in% "Expected change in daily cases"][
+    estimates[measure == "Expected change in daily cases"][
       ,
       .(region,
        `Expected change in daily cases` = estimate,
@@ -282,7 +282,7 @@ regional_summary <- function(regional_output = NULL,
 
   # adaptive add a logscale to the summary plot based on range of observed cases
   current_inf <- summarised_results$data[
-    metric %in% "New confirmed cases by infection date"
+    metric == "New confirmed cases by infection date"
   ]
   uppers <- grepl("upper_", colnames(current_inf), fixed = TRUE) # nolint
   lowers <- grepl("lower_", colnames(current_inf), fixed = TRUE) # nolint
@@ -756,7 +756,7 @@ summary.epinow <- function(object, output = "estimates",
                            ...) {
   choices <- c("estimates", "forecast", "estimated_reported_cases")
   output <- arg_match(output, values = choices, multiple = FALSE)
-  if (output %in% "estimates") {
+  if (output == "estimates") {
     out <- summary(object$estimates,
       date = date,
       params = params, ...
@@ -811,7 +811,7 @@ summary.estimate_infections <- function(object, type = "snapshot",
     target_date <- as.Date(date)
   }
 
-  if (type %in% "snapshot") {
+  if (type == "snapshot") {
     out <- report_summary(
       summarised_estimates = object$summarised[date == target_date],
       rt_samples = object$samples[variable == "R"][
@@ -820,7 +820,7 @@ summary.estimate_infections <- function(object, type = "snapshot",
       ...
     )
   } else if (type %in% c("parameters", "samples")) {
-    if (type %in% "parameters") {
+    if (type == "parameters") {
       type <- "summarised"
     }
     out <- object[[type]]

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -12,7 +12,7 @@ gp_opts(
   ls_min = 0,
   ls_max = 60,
   alpha_sd = 0.05,
-  kernel = "matern",
+  kernel = "matern_3/2",
   matern_type = 3/2
 )
 }

--- a/tests/testthat/test-create_future-rt.R
+++ b/tests/testthat/test-create_future-rt.R
@@ -6,7 +6,9 @@ test_that("create_future_rt works as expected", {
 
   test_frt(EpiNow2:::create_future_rt(), list(fixed = TRUE, from = 0))
   test_frt(EpiNow2:::create_future_rt("project"), list(fixed = FALSE, from = 0))
-  test_frt(EpiNow2:::create_future_rt("est", 10), list(fixed = TRUE, from = -10))
+  test_frt(
+    EpiNow2:::create_future_rt("estimate", 10), list(fixed = TRUE, from = -10)
+  )
   test_frt(EpiNow2:::create_future_rt(-3), list(fixed = TRUE, from = -3))
   test_frt(EpiNow2:::create_future_rt(3), list(fixed = TRUE, from = 3))
 })

--- a/tests/testthat/test-dist.R
+++ b/tests/testthat/test-dist.R
@@ -9,12 +9,12 @@ test_that("distributions are the same in R and stan", {
     do.call(gamma_dist_def, (c(args, list(samples = 1))))$params[[1]]
   pmf_r_lognormal <- dist_skel(
     n = seq_len(args$max_value + 1) - 1, dist = TRUE, cum = FALSE,
-    model = "lognormal", params = lognormal_params, max_value = args$max,
+    model = "lognormal", params = lognormal_params, max_value = args$max_value,
     discrete = TRUE
   )
   pmf_r_gamma <- dist_skel(
     n = seq_len(args$max_value + 1) - 1, dist = TRUE, cum = FALSE,
-    model = "gamma", params = gamma_params, max_value = args$max,
+    model = "gamma", params = gamma_params, max_value = args$max_value,
     discrete = TRUE
   )
 


### PR DESCRIPTION
This PR closes #499 by replacing all `match.arg()` calls with `rlang::arg_match()` because the latter prevents partial matching by throwing an error. 

The PR also fixes previously partially matched arguments.