### PR TITLE
deprecate `fixed` argument to `dist_spec`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 * The functions `get_dist`, `get_generation_time`, `get_incubation_period` have been deprecated and replaced with examples. By @sbfnk in #481 and reviewed by @seabbs.
 * The utility function `update_list()` has been deprecated in favour of `utils::modifyList()` because it comes with an installation of R. By @jamesmbaazam in #491 and reviewed by @seabbs.
+* The `fixed` argument to `dist_spec` has been deprecated and replaced by a `fix_dist()` function. By @sbfnk in #503 and reviewed by @seabbs.
 
 ## Documentation
 

--- a/R/dist.R
+++ b/R/dist.R
@@ -884,7 +884,7 @@ tune_inv_gamma <- function(lower = 2, upper = 21) {
 #' empty vector corresponding to a parametric specification of the distribution
 #' (using \code{mean}, \code{sd} and corresponding uncertainties)
 #'
-#' @param fixed Logical, defaults to `FALSE`. Should delays be treated
+#' @param fixed Deprecated, use [fix_dist() instead]
 #' as coming from fixed (vs uncertain) distributions. Overrides any values
 #' assigned to \code{mean_sd} and \code{sd_sd} by setting them to zero.
 #' reduces compute requirement but may produce spuriously precise estimates.
@@ -918,6 +918,17 @@ dist_spec <- function(mean, sd = 0, mean_sd = 0, sd_sd = 0,
     .frequency = "regularly",
     .frequency_id = "dist_spec_max"
   )
+  ## check for deprecated parameters
+  if (!missing(fixed)) {
+    deprecate_warn(
+      "2.0.0",
+      "dist_spec(fixed)",
+      "fix_dist()",
+      "The argument will be removed completely in version 2.1.0."
+    )
+    mean_sd <- 0
+    sd_sd <- 0
+  }
   ## check if parametric or nonparametric
   if (length(pmf) > 0 &&
     !all(

--- a/tests/testthat/test-dist_spec.R
+++ b/tests/testthat/test-dist_spec.R
@@ -227,3 +227,7 @@ test_that("plot.dist_spec correctly plots a combination of fixed distributions",
   expect_equal(length(plot$layers), 2)
   expect_equal(length(plot$facet$params$facets), 1)
 })
+
+test_that("deprecated arguments are caught", {
+  expect_deprecated(dist_spec(mean = 1.6, sd = 0.6, max = 19, fixed = TRUE))
+})


### PR DESCRIPTION
Deprecates the `fixed` argument in `dist_spec` as this can now be done with `fix_dist()` so that we can trim down the argument list.