### PR TITLE
Add support for missing NAs in estimate_infection() model

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,7 @@
 * The functions `get_dist`, `get_generation_time`, `get_incubation_period` have been deprecated and replaced with examples. By @sbfnk in #481 and reviewed by @seabbs.
 * The utility function `update_list()` has been deprecated in favour of `utils::modifyList()` because it comes with an installation of R. By @jamesmbaazam in #491 and reviewed by @seabbs.
 * The `fixed` argument to `dist_spec` has been deprecated and replaced by a `fix_dist()` function. By @sbfnk in #503 and reviewed by @seabbs.
+* Updated `estimate_infections()` so that rather than imputing missing data, it now skips these data points in the likelihood. This is a breaking change as it changes the behaviour of the model when dates are missing from a time series but are known to be zero. We recommend that users check their results when updating to this version. By @seabbs in # and reviewed by @sbfnk.
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The functions `get_dist`, `get_generation_time`, `get_incubation_period` have been deprecated and replaced with examples. By @sbfnk in #481 and reviewed by @seabbs.
 * The utility function `update_list()` has been deprecated in favour of `utils::modifyList()` because it comes with an installation of R. By @jamesmbaazam in #491 and reviewed by @seabbs.
 * The `fixed` argument to `dist_spec` has been deprecated and replaced by a `fix_dist()` function. By @sbfnk in #503 and reviewed by @seabbs.
-* Updated `estimate_infections()` so that rather than imputing missing data, it now skips these data points in the likelihood. This is a breaking change as it changes the behaviour of the model when dates are missing from a time series but are known to be zero. We recommend that users check their results when updating to this version. By @seabbs in # and reviewed by @sbfnk.
+* Updated `estimate_infections()` so that rather than imputing missing data, it now skips these data points in the likelihood. This is a breaking change as it alters the behaviour of the model when dates are missing from a time series but are known to be zero. We recommend that users check their results when updating to this version but expect this to in most cases improve performance. By @seabbs in # and reviewed by @sbfnk.
 
 ## Documentation
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@
 * The functions `get_dist`, `get_generation_time`, `get_incubation_period` have been deprecated and replaced with examples. By @sbfnk in #481 and reviewed by @seabbs.
 * The utility function `update_list()` has been deprecated in favour of `utils::modifyList()` because it comes with an installation of R. By @jamesmbaazam in #491 and reviewed by @seabbs.
 * The `fixed` argument to `dist_spec` has been deprecated and replaced by a `fix_dist()` function. By @sbfnk in #503 and reviewed by @seabbs.
-* Updated `estimate_infections()` so that rather than imputing missing data, it now skips these data points in the likelihood. This is a breaking change as it alters the behaviour of the model when dates are missing from a time series but are known to be zero. We recommend that users check their results when updating to this version but expect this to in most cases improve performance. By @seabbs in # and reviewed by @sbfnk.
+* Updated `estimate_infections()` so that rather than imputing missing data, it now skips these data points in the likelihood. This is a breaking change as it alters the behaviour of the model when dates are missing from a time series but are known to be zero. We recommend that users check their results when updating to this version but expect this to in most cases improve performance. By @seabbs in #528 and reviewed by @sbfnk.
 
 ## Documentation
 

--- a/R/create.R
+++ b/R/create.R
@@ -431,7 +431,7 @@ create_stan_data <- function(reported_cases, seeding_time,
 
   cases <- reported_cases[(seeding_time + 1):(.N - horizon)]$confirm
   cases <- cases$confirm
-  cases[, lookup := seq_len(.N))]]
+  cases[, lookup := seq_len(.N)]
   complete_cases <- cases[!is.na(cases$confirm)]
   complete_cases <- cases$confirm
   cases_time <- cases$lookup

--- a/R/create.R
+++ b/R/create.R
@@ -13,8 +13,10 @@
 #' threshold then the zero is replaced using `fill`.
 #'
 #' @param fill Numeric, defaults to NA. Value to use to replace NA values or
-#' zeros that are flagged by `zero_threshold`. If the default NA is used then
-#' dates with NA values will be skipped in model fitting.
+#' zeroes that are flagged because the 7-day average is above the
+#' `zero_threshold`. If the default NA is used then dates with NA values or with
+#' 7-day averages above the `zero_threshold` will be skipped in model fitting. If
+#' this is set to 0 then the only effect is to replace NA values with 0.
 #'
 #' @inheritParams estimate_infections
 #' @importFrom data.table copy merge.data.table setorder setDT frollsum

--- a/R/create.R
+++ b/R/create.R
@@ -9,14 +9,14 @@
 #'
 #' @param zero_threshold `r lifecycle::badge("experimental")` Numeric defaults
 #' to Inf. Indicates if detected zero cases are meaningful by using a threshold
-#' number of cases based on the 7 day average. If the average is above this
+#' number of cases based on the 7-day average. If the average is above this
 #' threshold then the zero is replaced using `fill`.
 #'
 #' @param fill Numeric, defaults to NA. Value to use to replace NA values or
 #' zeroes that are flagged because the 7-day average is above the
 #' `zero_threshold`. If the default NA is used then dates with NA values or with
-#' 7-day averages above the `zero_threshold` will be skipped in model fitting. If
-#' this is set to 0 then the only effect is to replace NA values with 0.
+#' 7-day averages above the `zero_threshold` will be skipped in model fitting.
+#' If this is set to 0 then the only effect is to replace NA values with 0.
 #'
 #' @inheritParams estimate_infections
 #' @importFrom data.table copy merge.data.table setorder setDT frollsum

--- a/R/create.R
+++ b/R/create.R
@@ -1,7 +1,8 @@
 #' Create Clean Reported Cases
 #' @description `r lifecycle::badge("stable")`
-#' Filters leading zeros and applies an optional threshold at which point 0 cases are replaced
-#' with a moving average of observed cases. See `zero_threshold` for details.
+#' Filters leading zeros and applies an optional threshold at which point
+#' 0 cases are replaced with a moving average of observed cases. See
+#' `zero_threshold` for details.
 #'
 #' @param filter_leading_zeros Logical, defaults to TRUE. Should zeros at the
 #' start of the time series be filtered out.
@@ -436,8 +437,8 @@ create_stan_data <- function(reported_cases, seeding_time,
   cases <- reported_cases[(seeding_time + 1):(.N - horizon)]
   cases[, lookup := seq_len(.N)]
   complete_cases <- cases[!is.na(cases$confirm)]
-  complete_cases <- cases$confirm
-  cases_time <- cases$lookup
+  complete_cases <- complete_cases$confirm
+  cases_time <- complete_cases$lookup
   cases <- cases$confirm
 
   data <- list(

--- a/R/create.R
+++ b/R/create.R
@@ -429,12 +429,12 @@ create_stan_data <- function(reported_cases, seeding_time,
                              rt, gp, obs, horizon,
                              backcalc, shifted_cases) {
 
-  cases <- reported_cases[(seeding_time + 1):(.N - horizon)]$confirm
-  cases <- cases$confirm
+  cases <- reported_cases[(seeding_time + 1):(.N - horizon)]
   cases[, lookup := seq_len(.N)]
   complete_cases <- cases[!is.na(cases$confirm)]
   complete_cases <- cases$confirm
   cases_time <- cases$lookup
+  cases <- cases$confirm
 
   data <- list(
     cases = complete_cases,

--- a/R/create.R
+++ b/R/create.R
@@ -434,6 +434,10 @@ create_stan_data <- function(reported_cases, seeding_time,
                              backcalc, shifted_cases) {
 
   cases <- reported_cases[(seeding_time + 1):(.N - horizon)]$confirm
+  cases[, lookup := seq_len(.N))]]
+  cases <- cases[!is.na(cases$confirm)]
+  cases <- cases$confirm
+  cases_time <- cases$lookup
 
   data <- list(
     cases = cases,

--- a/R/create.R
+++ b/R/create.R
@@ -49,7 +49,9 @@ create_clean_reported_cases <- function(reported_cases, horizon,
       date >= min(date[confirm[!is.na(confirm)] > 0])
     ]
   }
-  # Calculate the 7-day moving average.
+  # Calculate `average_7_day` which for rows with `confirm == 0`
+  # (the only instance where this is being used) equates to the 7-day
+  # right-aligned moving average at the previous data point.
   reported_cases <-
     reported_cases[
       ,

--- a/R/create.R
+++ b/R/create.R
@@ -467,7 +467,7 @@ create_stan_data <- function(reported_cases, seeding_time,
       delay = data$seeding_time, horizon = data$horizon
     )
   )
-  # initial estimate of growth33
+  # initial estimate of growth
   first_week <- data.table::data.table(
     confirm = cases[seq_len(min(7, length(cases)))],
     t = seq_len(min(7, length(cases)))

--- a/R/create.R
+++ b/R/create.R
@@ -38,10 +38,7 @@ create_clean_reported_cases <- function(reported_cases, horizon,
   reported_cases <- data.table::setorder(reported_cases, date)
   ## Filter out 0 reported cases from the beginning of the data
   if (filter_leading_zeros) {
-    reported_cases <- reported_cases[order(date)][
-      ,
-      cum_cases := cumsum(confirm, na.rm = TRUE)
-    ][min(date[cum_cases > 0])][, cum_cases := NULL]
+    reported_cases <- reported_cases[order(date)][min(date[confirm > 0])]
   }
 
   # Check case counts preceding zero case counts and set to 7 day average if

--- a/R/create.R
+++ b/R/create.R
@@ -18,6 +18,8 @@
 #' @author Sam Abbott
 #' @author Lloyd Chapman
 #' @export
+#' @examples
+#' create_clean_reported_cases(example_confirmed, 7)
 create_clean_reported_cases <- function(reported_cases, horizon,
                                         filter_leading_zeros = TRUE,
                                         zero_threshold = Inf) {
@@ -38,7 +40,9 @@ create_clean_reported_cases <- function(reported_cases, horizon,
   reported_cases <- data.table::setorder(reported_cases, date)
   ## Filter out 0 reported cases from the beginning of the data
   if (filter_leading_zeros) {
-    reported_cases <- reported_cases[order(date)][min(date[confirm > 0])]
+    reported_cases <- reported_cases[order(date)][
+      date >= min(date[confirm[!is.na(confirm)] > 0])
+    ]
   }
 
   # Check case counts preceding zero case counts and set to 7 day average if

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -165,7 +165,7 @@ estimate_infections <- function(reported_cases,
       name = "EpiNow2.epinow.estimate_infections"
     )
   }
-  # Make sure there are no missing dates and order cases
+  # Order cases
   reported_cases <- create_clean_reported_cases(
     reported_cases, horizon,
     filter_leading_zeros = filter_leading_zeros,

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -444,9 +444,9 @@ globalVariables(
     "New confirmed cases by infection date", "Data", "R", "reference",
     ".SD", "day_of_week", "forecast_type", "measure", "numeric_estimate",
     "point", "strat", "estimate", "breakpoint", "variable", "value.V1",
-    "central_lower", "central_upper", "mean_sd", "sd_sd", "average_7",
+    "central_lower", "central_upper", "mean_sd", "sd_sd", "average_7_day",
     "..lowers", "..upper_CrI", "..uppers", "timing", "dataset", "last_confirm",
     "report_date", "secondary", "id", "conv", "meanlog", "primary", "scaled",
-    "scaling", "sdlog"
+    "scaling", "sdlog", "lookup"
   )
 )

--- a/inst/stan/data/observations.stan
+++ b/inst/stan/data/observations.stan
@@ -1,6 +1,8 @@
   int t;                                            // unobserved time
+  int lt;                          // timepoints in the likelihood
   int seeding_time;                                 // time period used for seeding and not observed
   int horizon;                                      // forecast horizon
   int future_time;                                  // time in future for Rt
-  array[t - horizon - seeding_time] int<lower = 0> cases; // observed cases
+  array[lt] int<lower = 0> cases; // observed cases
+  array[lt] int cases_time; // time of observed cases
   vector<lower = 0>[t] shifted_cases;               // prior infections (for backcalculation)

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -148,7 +148,8 @@ model {
   // observed reports from mean of reports (update likelihood)
   if (likelihood) {
     report_lp(
-      cases, obs_reports, rep_phi, phi_mean, phi_sd, model_type, obs_weight
+      cases, obs_reports[cases_time], rep_phi, phi_mean, phi_sd, model_type,
+      obs_weight
     );
   }
 }
@@ -191,7 +192,7 @@ generated quantities {
   // log likelihood of model
   if (return_likelihood) {
     log_lik = report_log_lik(
-      cases, obs_reports, rep_phi, model_type, obs_weight
+      cases, obs_reports[cases_time], rep_phi, model_type, obs_weight
     );
   }
 }

--- a/man/create_clean_reported_cases.Rd
+++ b/man/create_clean_reported_cases.Rd
@@ -8,7 +8,8 @@ create_clean_reported_cases(
   reported_cases,
   horizon,
   filter_leading_zeros = TRUE,
-  zero_threshold = Inf
+  zero_threshold = Inf,
+  fill = NA_integer_
 )
 }
 \arguments{
@@ -24,17 +25,23 @@ start of the time series be filtered out.}
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
 number of cases based on the 7 day average. If the average is above this
-threshold then the zero is replaced with the backwards looking rolling
-average. If set to infinity then no changes are made.}
+threshold then the zero is replaced using \code{fill}.}
+
+\item{fill}{Numeric, defaults to NA. Value to use to replace NA values or
+zeros that are flagged by \code{zero_threshold}. If the default NA is used then
+dates with NA values will be skipped in model fitting.}
 }
 \value{
 A cleaned data frame of reported cases
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-Cleans a data frame of reported cases by replacing missing dates with 0
-cases and applies an optional threshold at which point 0 cases are replaced
-with a moving average of observed cases. See \code{zero_threshold} for details.
+Filters leading zeros, completes dates, and applies an optional threshold at
+which point 0 cases are replaced with a user supplied value (defaults to
+\code{NA}).
+}
+\examples{
+create_clean_reported_cases(example_confirmed, 7)
 }
 \author{
 Sam Abbott

--- a/man/create_clean_reported_cases.Rd
+++ b/man/create_clean_reported_cases.Rd
@@ -24,12 +24,14 @@ start of the time series be filtered out.}
 
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
-number of cases based on the 7 day average. If the average is above this
+number of cases based on the 7-day average. If the average is above this
 threshold then the zero is replaced using \code{fill}.}
 
 \item{fill}{Numeric, defaults to NA. Value to use to replace NA values or
-zeros that are flagged by \code{zero_threshold}. If the default NA is used then
-dates with NA values will be skipped in model fitting.}
+zeroes that are flagged because the 7-day average is above the
+\code{zero_threshold}. If the default NA is used then dates with NA values or with
+7-day averages above the \code{zero_threshold} will be skipped in model fitting.
+If this is set to 0 then the only effect is to replace NA values with 0.}
 }
 \value{
 A cleaned data frame of reported cases

--- a/man/create_stan_data.Rd
+++ b/man/create_stan_data.Rd
@@ -50,6 +50,12 @@ stan. Internally calls the other \code{create_} family of functions to
 construct a single list for input into stan with all data required
 present.
 }
+\examples{
+create_stan_data(
+ example_confirmed, 7, rt_opts(), gp_opts(), obs_opts(), 7,
+ backcalc_opts(), create_shifted_cases(example_confirmed, 7, 14, 7)
+)
+}
 \author{
 Sam Abbott
 

--- a/man/epinow.Rd
+++ b/man/epinow.Rd
@@ -72,7 +72,7 @@ start of the time series be filtered out.}
 
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
-number of cases based on the 7 day average. If the average is above this
+number of cases based on the 7-day average. If the average is above this
 threshold then the zero is replaced using \code{fill}.}
 
 \item{return_output}{Logical, defaults to FALSE. Should output be returned,

--- a/man/epinow.Rd
+++ b/man/epinow.Rd
@@ -73,8 +73,7 @@ start of the time series be filtered out.}
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
 number of cases based on the 7 day average. If the average is above this
-threshold then the zero is replaced with the backwards looking rolling
-average. If set to infinity then no changes are made.}
+threshold then the zero is replaced using \code{fill}.}
 
 \item{return_output}{Logical, defaults to FALSE. Should output be returned,
 this automatically updates to TRUE if no directory for saving is specified.}

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -69,8 +69,7 @@ start of the time series be filtered out.}
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
 number of cases based on the 7 day average. If the average is above this
-threshold then the zero is replaced with the backwards looking rolling
-average. If set to infinity then no changes are made.}
+threshold then the zero is replaced using \code{fill}.}
 
 \item{weigh_delay_priors}{Logical. If TRUE (default), all delay distribution
 priors will be weighted by the number of observation data points, in doing so

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -68,7 +68,7 @@ start of the time series be filtered out.}
 
 \item{zero_threshold}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#experimental}{\figure{lifecycle-experimental.svg}{options: alt='[Experimental]'}}}{\strong{[Experimental]}} Numeric defaults
 to Inf. Indicates if detected zero cases are meaningful by using a threshold
-number of cases based on the 7 day average. If the average is above this
+number of cases based on the 7-day average. If the average is above this
 threshold then the zero is replaced using \code{fill}.}
 
 \item{weigh_delay_priors}{Logical. If TRUE (default), all delay distribution

--- a/tests/testthat/test-create_clean_reported_cases.R
+++ b/tests/testthat/test-create_clean_reported_cases.R
@@ -15,7 +15,9 @@ test_that("create_clean_reported_cases filters leading zeros correctly", {
   
   result <- create_clean_reported_cases(modified_data, 7)
   # Check if the first row with non-zero cases is retained
-  expect_equal(result$date[1], min(modified_data$date[modified_data$confirm > 0]))
+  expect_equal(
+    result$date[1], min(modified_data$date[modified_data$confirm > 0])
+  )
 })
 
 test_that("create_clean_reported_cases replaces zero cases correctly", {

--- a/tests/testthat/test-create_clean_reported_cases.R
+++ b/tests/testthat/test-create_clean_reported_cases.R
@@ -1,0 +1,32 @@
+
+test_that("create_clean_reported_cases runs without errors", {
+  expect_no_error(create_clean_reported_cases(example_confirmed, 7))
+})
+
+test_that("create_clean_reported_cases returns a data table", {
+  result <- create_clean_reported_cases(example_confirmed, 7)
+  expect_s3_class(result, "data.table")
+})
+
+test_that("create_clean_reported_cases filters leading zeros correctly", {
+  # Modify example_confirmed to have leading zeros
+  modified_data <- example_confirmed
+  modified_data[1:3, "confirm"] <- 0
+  
+  result <- create_clean_reported_cases(modified_data, 7)
+  # Check if the first row with non-zero cases is retained
+  expect_equal(result$date[1], min(modified_data$date[modified_data$confirm > 0]))
+})
+
+test_that("create_clean_reported_cases replaces zero cases correctly", {
+  # Modify example_confirmed to have zero cases that should be replaced
+  modified_data <- example_confirmed
+  modified_data$confirm[10:16] <- 0
+  threshold <- 10
+  
+  result <- create_clean_reported_cases(
+    modified_data, 0, zero_threshold = threshold
+  )
+  # Check if zero cases within the threshold are replaced
+  expect_equal(sum(result$confirm == 0, na.rm = TRUE), 0)
+})

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -36,6 +36,14 @@ test_that("estimate_infections successfully returns estimates using default sett
   test_estimate_infections(reported_cases)
 })
 
+test_that("estimate_infections successfully returns estimates when passed NA values", {
+  skip_on_cran()
+  reported_cases_na <- data.table::copy(reported_cases)
+  reported_cases_na[sample(1:30, 5), confirm := NA]
+  test_estimate_infections(reported_cases_na)
+})
+
+
 test_that("estimate_infections successfully returns estimates using no delays", {
   skip_on_cran()
   test_estimate_infections(reported_cases, delay = FALSE)


### PR DESCRIPTION
This PR adds support for missing data in the form of NAs but dropping them from the likelihood rather than imputing that they are zero and then optionally 

Note that this is a breaking change and may be undesirable for some users where missing dates do indicate zeros vs being truly missing. 

I have tested by knocking out data from the example and running the model.