### PR TITLE
Fix default values for `generation_time` argument

### DIFF
--- a/R/epinow.R
+++ b/R/epinow.R
@@ -90,7 +90,7 @@
 #' options(old_opts)
 #' }
 epinow <- function(reported_cases,
-                   generation_time = NULL,
+                   generation_time = generation_time_opts(),
                    delays = delay_opts(),
                    truncation = trunc_opts(),
                    rt = rt_opts(),

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -142,9 +142,14 @@
 #' options(old_opts)
 estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
                                 trunc_dist = "lognormal",
-                                truncation = dist_spec(
-                                  mean = 0, sd = 0, mean_sd = 1, sd_sd = 1,
-                                  max = 10
+                                truncation = trunc_opts(
+                                  dist_spec(
+                                    mean = 0,
+                                    mean_sd = 1,
+                                    sd = 0,
+                                    sd_sd = 1,
+                                    max = 10
+                                  )
                                 ),
                                 model = NULL,
                                 stan = stan_opts(),

--- a/R/regional_epinow.R
+++ b/R/regional_epinow.R
@@ -89,7 +89,7 @@
 #' options(old_opts)
 #' }
 regional_epinow <- function(reported_cases,
-                            generation_time,
+                            generation_time = generation_time_opts(),
                             delays = delay_opts(),
                             truncation = trunc_opts(),
                             rt = rt_opts(),

--- a/man/epinow.Rd
+++ b/man/epinow.Rd
@@ -6,7 +6,7 @@
 \usage{
 epinow(
   reported_cases,
-  generation_time = NULL,
+  generation_time = generation_time_opts(),
   delays = delay_opts(),
   truncation = trunc_opts(),
   rt = rt_opts(),

--- a/man/estimate_truncation.Rd
+++ b/man/estimate_truncation.Rd
@@ -9,7 +9,7 @@ estimate_truncation(
   max_truncation,
   trunc_max = 10,
   trunc_dist = "lognormal",
-  truncation = dist_spec(mean = 0, sd = 0, mean_sd = 1, sd_sd = 1, max = 10),
+  truncation = trunc_opts(dist_spec(mean = 0, mean_sd = 1, sd = 0, sd_sd = 1, max = 10)),
   model = NULL,
   stan = stan_opts(),
   CrIs = c(0.2, 0.5, 0.9),

--- a/man/regional_epinow.Rd
+++ b/man/regional_epinow.Rd
@@ -6,7 +6,7 @@
 \usage{
 regional_epinow(
   reported_cases,
-  generation_time,
+  generation_time = generation_time_opts(),
   delays = delay_opts(),
   truncation = trunc_opts(),
   rt = rt_opts(),


### PR DESCRIPTION
## Description

This PR closes #494.

The default value for `generation_time` in `epinow()` and `regional_epinow()` were previously "empty" and `NULL` respectively, but these have now been replaced with `generation_time_opts()` to align with the defaults of other arguments requiring `*_opts()` calls.

The default value of `truncation` in `estimate_truncation()` is now also passed through a call to `trunc_opts`.

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

