### PR TITLE
Move up version for deprecation warnings

### DIFF
--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -287,8 +287,6 @@ estimate_infections <- function(reported_cases,
 #'
 #' @description `r lifecycle::badge("deprecated")`
 #'
-#' This function has been deprecated and will be removed in version 2.0.0.
-#'
 #' Fits a model to cumulative cases. This may be a useful approach to
 #' initialising a full model fit for certain data sets where the sampler gets
 #' stuck or cannot easily be initialised as fitting to cumulative cases changes

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -320,8 +320,7 @@ init_cumulative_fit <- function(args, samples = 50, warmup = 50,
                                 backend = "rstan") {
   deprecate_warn(
     when = "1.5.0",
-    what = "init_cumulative_fit()",
-    details = "The function will be removed completely in version 2.0.0."
+    what = "init_cumulative_fit()"
   )
   futile.logger::flog.debug(
     "%s: Fitting to cumulative data to initialise chains", id,

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -189,8 +189,7 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
     deprecate_warn(
       "1.4.0",
       "estimate_truncation(trunc_max)",
-      "estimate_truncation(truncation)",
-      "The argument will be removed completely in version 2.0.0."
+      "estimate_truncation(truncation)"
     )
     construct_trunc <- TRUE
   }
@@ -203,8 +202,7 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
     deprecate_warn(
       "1.4.0",
       "estimate_truncation(max_truncation)",
-      "estimate_truncation(truncation)",
-      "The argument will be removed completely in version 2.0.0."
+      "estimate_truncation(truncation)"
     )
     trunc_max <- max_truncation
     construct_trunc <- TRUE
@@ -219,8 +217,7 @@ estimate_truncation <- function(obs, max_truncation, trunc_max = 10,
     deprecate_warn(
       "1.4.0",
       "estimate_truncation(trunc_dist)",
-      "estimate_truncation(truncation)",
-      "The argument will be removed completely in version 2.0.0."
+      "estimate_truncation(truncation)"
     )
     construct_trunc <- TRUE
   }

--- a/R/get.R
+++ b/R/get.R
@@ -181,7 +181,7 @@ get_regional_results <- function(regional_output,
 #' @export
 get_dist <- function(data, disease, source, max_value = 14, fixed = FALSE) {
   lifecycle::deprecate_warn(
-    "2.0.0", "get_dist()", "dist_spec()",
+    "1.5.0", "get_dist()", "dist_spec()",
     "The function will be removed completely in version 2.1.0."
   )
   target_disease <- disease
@@ -212,7 +212,7 @@ get_dist <- function(data, disease, source, max_value = 14, fixed = FALSE) {
 get_generation_time <- function(disease, source, max_value = 14,
                                 fixed = FALSE) {
   lifecycle::deprecate_warn(
-    "2.0.0", "get_generation_time()", "dist_spec()",
+    "1.5.0", "get_generation_time()", "dist_spec()",
     paste(
       "The function will be removed completely in version 2.1.0. To obtain the",
       "previous estimate by Ganyani et al. (2020) use ",
@@ -242,7 +242,7 @@ get_generation_time <- function(disease, source, max_value = 14,
 get_incubation_period <- function(disease, source, max_value = 14,
                                   fixed = FALSE) {
   lifecycle::deprecate_warn(
-    "2.0.0", "get_incubation_period()", "dist_spec()",
+    "1.5.0", "get_incubation_period()", "dist_spec()",
     paste(
       "The function will be removed completely in version 2.1.0. To obtain the",
       "previous estimate by Ganyani et al. (2020) use ",

--- a/R/get.R
+++ b/R/get.R
@@ -181,8 +181,7 @@ get_regional_results <- function(regional_output,
 #' @export
 get_dist <- function(data, disease, source, max_value = 14, fixed = FALSE) {
   lifecycle::deprecate_warn(
-    "1.5.0", "get_dist()", "dist_spec()",
-    "The function will be removed completely in version 2.1.0."
+    "1.5.0", "get_dist()", "dist_spec()"
   )
   target_disease <- disease
   target_source <- source
@@ -214,8 +213,7 @@ get_generation_time <- function(disease, source, max_value = 14,
   lifecycle::deprecate_warn(
     "1.5.0", "get_generation_time()", "dist_spec()",
     paste(
-      "The function will be removed completely in version 2.1.0. To obtain the",
-      "previous estimate by Ganyani et al. (2020) use ",
+      "To obtain the previous estimate by Ganyani et al. (2020) use ",
       "`example_generation_time`"
     )
   )
@@ -244,8 +242,7 @@ get_incubation_period <- function(disease, source, max_value = 14,
   lifecycle::deprecate_warn(
     "1.5.0", "get_incubation_period()", "dist_spec()",
     paste(
-      "The function will be removed completely in version 2.1.0. To obtain the",
-      "previous estimate by Ganyani et al. (2020) use ",
+      "To obtain the previous estimate by Ganyani et al. (2020) use ",
       "`example_incubation_period`"
     )
   )

--- a/R/opts.R
+++ b/R/opts.R
@@ -616,8 +616,7 @@ rstan_sampling_opts <- function(cores = getOption("mc.cores", 1L),
                                 ...) {
   lifecycle::deprecate_warn(
     "1.5.0", "rstan_sampling_opts()",
-    "stan_sampling_opts()",
-     "This function will be removed in version 2.1.0."
+    "stan_sampling_opts()"
   )
   return(stan_sampling_opts(
     cores, warmup, samples, chains, control, save_warmup, seed, future,
@@ -736,8 +735,7 @@ rstan_vb_opts <- function(samples = 2000,
                           iter = 10000, ...) {
   lifecycle::deprecate_warn(
     "1.5.0", "rstan_vb_opts()",
-    "stan_vb_opts()",
-     "This function will be removed in version 2.1.0."
+    "stan_vb_opts()"
   )
   return(stan_vb_opts(samples, trials, iter, ...))
 }
@@ -803,8 +801,7 @@ rstan_opts <- function(object = NULL,
                        method = "sampling", ...) {
   lifecycle::deprecate_warn(
     "1.5.0", "rstan_opts()",
-    "stan_opts()",
-     "This function will be removed in version 2.1.0."
+    "stan_opts()"
   )
   method <- arg_match(method, values = c("sampling", "vb"))
   # shared everywhere opts

--- a/R/opts.R
+++ b/R/opts.R
@@ -615,7 +615,7 @@ rstan_sampling_opts <- function(cores = getOption("mc.cores", 1L),
                                 max_execution_time = Inf,
                                 ...) {
   lifecycle::deprecate_warn(
-    "2.0.0", "rstan_sampling_opts()",
+    "1.5.0", "rstan_sampling_opts()",
     "stan_sampling_opts()",
      "This function will be removed in version 2.1.0."
   )
@@ -735,7 +735,7 @@ rstan_vb_opts <- function(samples = 2000,
                           trials = 10,
                           iter = 10000, ...) {
   lifecycle::deprecate_warn(
-    "2.0.0", "rstan_vb_opts()",
+    "1.5.0", "rstan_vb_opts()",
     "stan_vb_opts()",
      "This function will be removed in version 2.1.0."
   )
@@ -802,7 +802,7 @@ rstan_opts <- function(object = NULL,
                        samples = 2000,
                        method = "sampling", ...) {
   lifecycle::deprecate_warn(
-    "2.0.0", "rstan_opts()",
+    "1.5.0", "rstan_opts()",
     "stan_opts()",
      "This function will be removed in version 2.1.0."
   )

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -63,7 +63,7 @@ simulate_infections <- function(estimates, R, initial_infections,
   ## deprecated usage
   if (!missing(estimates)) {
     deprecate_warn(
-      "2.0.0",
+      "1.5.0",
       "simulate_infections(estimates)",
       "forecast_infections()",
       details = paste0(

--- a/man/init_cumulative_fit.Rd
+++ b/man/init_cumulative_fit.Rd
@@ -36,8 +36,6 @@ A stanfit object
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
 
-This function has been deprecated and will be removed in version 2.0.0.
-
 Fits a model to cumulative cases. This may be a useful approach to
 initialising a full model fit for certain data sets where the sampler gets
 stuck or cannot easily be initialised as fitting to cumulative cases changes


### PR DESCRIPTION
## Description

This PR closes #573 by moving the deprecation warnings from version 2.0.0 to version 1.5.0.

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

