### PR TITLE
don't install pandoc in synthetic validation

### DIFF
--- a/.github/workflows/synthetic-validation.yaml
+++ b/.github/workflows/synthetic-validation.yaml
@@ -25,6 +25,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: NA
+          install-pandoc: false
           extra-packages: |
             here
             dplyr


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #585 (if it works) by explicitly not installing pandoc.

## Initial submission checklist

- [X] My PR is based on a package issue and I have explicitly linked it.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

