### PR TITLE
Only set seeds in testing when needed.

### DIFF
--- a/.github/workflows/R-CMD-as-cran-check.yaml
+++ b/.github/workflows/R-CMD-as-cran-check.yaml
@@ -39,6 +39,7 @@ jobs:
           dependencies: NA
           extra-packages: |
             rcmdcheck
+            rmarkdown
             stan-dev/cmdstanr
             testthat
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,6 +27,7 @@
 * Added the possibility of specifying a fixed observation scaling. By @sbfnk in #550 and reviewed by @seabbs.
 * Added the possibility of specifying fixed overdispersion. By @sbfnk in #560 and reviewed by @seabbs.
 * The example in `estimate_truncation()` has been simplified. The package now ships with a dataset `example_truncated`, which is used in the `estimate_truncation()` example and tests. The steps for creating the `example_truncated` is stored in `./data-raw/estimate-truncation.R`. By @jamesmbaazam in #584 and reviewed by @seabbs and @sbfnk.
+* Tests have been updated to only set random seeds before snapshot tests involving random number generation, and unset them subsequently. By @sbfnk in .
 
 ## Model changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -27,7 +27,7 @@
 * Added the possibility of specifying a fixed observation scaling. By @sbfnk in #550 and reviewed by @seabbs.
 * Added the possibility of specifying fixed overdispersion. By @sbfnk in #560 and reviewed by @seabbs.
 * The example in `estimate_truncation()` has been simplified. The package now ships with a dataset `example_truncated`, which is used in the `estimate_truncation()` example and tests. The steps for creating the `example_truncated` is stored in `./data-raw/estimate-truncation.R`. By @jamesmbaazam in #584 and reviewed by @seabbs and @sbfnk.
-* Tests have been updated to only set random seeds before snapshot tests involving random number generation, and unset them subsequently. By @sbfnk in .
+* Tests have been updated to only set random seeds before snapshot tests involving random number generation, and unset them subsequently. By @sbfnk in #590 and reviewed by @seabbs.
 
 ## Model changes
 

--- a/tests/testthat/_snaps/simulate-infections.md
+++ b/tests/testthat/_snaps/simulate-infections.md
@@ -16,20 +16,20 @@
     12:     infections 2023-01-12 117.41367
     13:     infections 2023-01-13  93.93093
     14:     infections 2023-01-14  75.14475
-    15: reported_cases 2023-01-01 128.00000
-    16: reported_cases 2023-01-02 151.00000
-    17: reported_cases 2023-01-03 145.00000
-    18: reported_cases 2023-01-04 188.00000
-    19: reported_cases 2023-01-05 252.00000
-    20: reported_cases 2023-01-06 276.00000
-    21: reported_cases 2023-01-07 371.00000
-    22: reported_cases 2023-01-08 273.00000
-    23: reported_cases 2023-01-09 234.00000
-    24: reported_cases 2023-01-10 192.00000
-    25: reported_cases 2023-01-11 157.00000
-    26: reported_cases 2023-01-12 120.00000
-    27: reported_cases 2023-01-13  78.00000
-    28: reported_cases 2023-01-14  63.00000
+    15: reported_cases 2023-01-01 125.00000
+    16: reported_cases 2023-01-02 135.00000
+    17: reported_cases 2023-01-03 195.00000
+    18: reported_cases 2023-01-04 224.00000
+    19: reported_cases 2023-01-05 253.00000
+    20: reported_cases 2023-01-06 328.00000
+    21: reported_cases 2023-01-07 364.00000
+    22: reported_cases 2023-01-08 278.00000
+    23: reported_cases 2023-01-09 206.00000
+    24: reported_cases 2023-01-10 169.00000
+    25: reported_cases 2023-01-11 144.00000
+    26: reported_cases 2023-01-12 109.00000
+    27: reported_cases 2023-01-13  80.00000
+    28: reported_cases 2023-01-14  95.00000
               variable       date     value
 
 # simulate_infections works as expected with additional parameters
@@ -50,19 +50,19 @@
     12:     infections 2023-01-12 190.8991
     13:     infections 2023-01-13 180.8132
     14:     infections 2023-01-14 171.1484
-    15: reported_cases 2023-01-01 425.0000
-    16: reported_cases 2023-01-02 335.0000
-    17: reported_cases 2023-01-03 376.0000
-    18: reported_cases 2023-01-04 250.0000
-    19: reported_cases 2023-01-05 301.0000
-    20: reported_cases 2023-01-06 275.0000
-    21: reported_cases 2023-01-07 844.0000
-    22: reported_cases 2023-01-08 235.0000
-    23: reported_cases 2023-01-09 205.0000
-    24: reported_cases 2023-01-10 251.0000
-    25: reported_cases 2023-01-11 239.0000
-    26: reported_cases 2023-01-12  80.0000
-    27: reported_cases 2023-01-13 128.0000
-    28: reported_cases 2023-01-14 276.0000
+    15: reported_cases 2023-01-01 155.0000
+    16: reported_cases 2023-01-02 563.0000
+    17: reported_cases 2023-01-03 146.0000
+    18: reported_cases 2023-01-04 644.0000
+    19: reported_cases 2023-01-05 282.0000
+    20: reported_cases 2023-01-06 473.0000
+    21: reported_cases 2023-01-07 193.0000
+    22: reported_cases 2023-01-08 262.0000
+    23: reported_cases 2023-01-09  19.0000
+    24: reported_cases 2023-01-10 277.0000
+    25: reported_cases 2023-01-11 177.0000
+    26: reported_cases 2023-01-12 273.0000
+    27: reported_cases 2023-01-13  97.0000
+    28: reported_cases 2023-01-14 265.0000
               variable       date    value
 

--- a/tests/testthat/test-report_cases.R
+++ b/tests/testthat/test-report_cases.R
@@ -6,7 +6,6 @@ test_that("report_cases can simulate infections forward", {
   # data for speed in this example.
   cases <- cases[, cases := as.integer(confirm)]
   cases <- cases[, confirm := NULL][, sample := 1]
-  set.seed(123)
   reported_cases <- report_cases(
     case_estimates = cases,
     delays = delay_opts(example_incubation_period + example_reporting_delay),

--- a/tests/testthat/test-simulate-infections.R
+++ b/tests/testthat/test-simulate-infections.R
@@ -16,12 +16,15 @@ test_simulate_infections <- function(obs = obs_opts(family = "poisson"), ...) {
 }
 
 test_that("simulate_infections works as expected with standard parameters", {
+  set.seed(123)
   sim <- test_simulate_infections()
   expect_equal(nrow(sim), 2 * nrow(R))
   expect_snapshot_output(sim)
+  set.seed(Sys.time())
 })
 
 test_that("simulate_infections works as expected with additional parameters", {
+  set.seed(123)
   sim <- test_simulate_infections(
     generation_time = generation_time_opts(fix_dist(example_generation_time)),
     delays = delay_opts(fix_dist(example_reporting_delay)),
@@ -29,6 +32,7 @@ test_that("simulate_infections works as expected with additional parameters", {
   )
   expect_equal(nrow(sim), 2 * nrow(R))
   expect_snapshot_output(sim)
+  set.seed(Sys.time())
 })
 
 test_that("simulate_infections fails with uncertain parameters", {

--- a/tests/testthat/test-stan-convole.R
+++ b/tests/testthat/test-stan-convole.R
@@ -15,7 +15,6 @@ test_that("convolve can combine two pmfs as expected", {
 })
 
 test_that("convolve performs the same as a numerical convolution", {
-  set.seed(123)
   # Sample and analytical PMFs for two Poisson distributions
   x <- rpois(10000, 3)
   xpmf <- dpois(0:20, 3)


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #558.

Specifically, it implements the suggestion in https://github.com/epiforecasts/EpiNow2/issues/558#issuecomment-1972881153

Seeds are now only set before doing a snapshot test involving number generation and unset again afterwards.

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [X] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

