### PR TITLE
Fix wrong call to vignette() in README

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -138,7 +138,7 @@ numbers and performing short-term forecasts for a disease spreading in a
 
 In different vignettes we provide the mathematical definition of each model.
 For example, the model definition vignette for `estimate_infections()` can be
-found in `vignettes("estimate_infections")`.
+found in `vignette("estimate_infections")`.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Model definitions
 In different vignettes we provide the mathematical definition of each
 model. For example, the model definition vignette for
 `estimate_infections()` can be found in
-`vignettes("estimate_infections")`.
+`vignette("estimate_infections")`.
 
 </details>
 <details>


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR does not close any issue but fixes a wrong call to `vignette()` that was causing a link to a vignette not to render in the changes introduced in #617.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

