### PR TITLE
Update DESCRIPTION - remove styler

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -133,7 +133,6 @@ Suggests:
     precommit,
     rmarkdown,
     spelling,
-    styler,
     testthat,
     tidyr,
     usethis,


### PR DESCRIPTION
As noted in #631 we have  `{styler}` in the suggests for no good reason. This PR removes it. 
