### PR TITLE
Update documentation of dots in `stan_sampling_opts()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 ## Documentation
 
-- Updated the documentation of the dots argument of the `stan_sampling_opts()` to add that the dots are passed to `cmdstanr::sample()`. By @jamesmbaazam in # and reviewed by @<REVIEWER>.
+- Updated the documentation of the dots argument of the `stan_sampling_opts()` to add that the dots are passed to `cmdstanr::sample()`. By @jamesmbaazam in #699 and reviewed by @sbfnk.
 
 # EpiNow2 1.5.2
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,10 @@
 
 - `epinow()` now returns the "timing" output in a "time difference"" format that is easier to understand and work with. By @jamesmbaazam in #688 and reviewed by @sbfnk.
 
+## Documentation
+
+- Updated the documentation of the dots argument of the `stan_sampling_opts()` to add that the dots are passed to `cmdstanr::sample()`. By @jamesmbaazam in # and reviewed by @<REVIEWER>.
+
 # EpiNow2 1.5.2
 
 A patch release to further fix an issue with the date in the package citation. This has now been addressed by removing `inst/CITATION`.

--- a/R/deprecated.R
+++ b/R/deprecated.R
@@ -386,6 +386,7 @@ get_incubation_period <- function(disease, source, max_value = 14,
 #'
 #' @description `r lifecycle::badge("deprecated")`
 #' Deprecated; use [stan_sampling_opts()] instead.
+#' @param ... Additional parameters to pass to [rstan::sampling()].
 #' @inheritParams stan_sampling_opts
 #' @return A list of arguments to pass to [rstan::sampling()].
 #' @export

--- a/R/opts.R
+++ b/R/opts.R
@@ -606,7 +606,8 @@ obs_opts <- function(family = c("negbin", "poisson"),
 #'
 #' @inheritParams stan_opts
 #'
-#' @param ... Additional parameters to pass to [rstan::sampling()].
+#' @param ... Additional parameters to pass to [rstan::sampling()] or
+#' [cmdstanr::sample()].
 #' @importFrom utils modifyList
 #' @return A list of arguments to pass to [rstan::sampling()] or
 #' [cmdstanr::sample()].

--- a/R/opts.R
+++ b/R/opts.R
@@ -609,7 +609,7 @@ obs_opts <- function(family = c("negbin", "poisson"),
 #' @param ... Additional parameters to pass to [rstan::sampling()].
 #' @importFrom utils modifyList
 #' @return A list of arguments to pass to [rstan::sampling()] or
-#' [cmdstanr::sample().
+#' [cmdstanr::sample()].
 #' @export
 #' @examples
 #' stan_sampling_opts(samples = 2000)

--- a/man/stan_sampling_opts.Rd
+++ b/man/stan_sampling_opts.Rd
@@ -55,7 +55,8 @@ estimation will fail with an informative error.}
 \item{backend}{Character string indicating the backend to use for fitting
 stan models. Supported arguments are "rstan" (default) or "cmdstanr".}
 
-\item{...}{Additional parameters to pass to \code{\link[rstan:stanmodel-method-sampling]{rstan::sampling()}}.}
+\item{...}{Additional parameters to pass to \code{\link[rstan:stanmodel-method-sampling]{rstan::sampling()}} or
+\code{\link[cmdstanr:model-method-sample]{cmdstanr::sample()}}.}
 }
 \value{
 A list of arguments to pass to \code{\link[rstan:stanmodel-method-sampling]{rstan::sampling()}} or

--- a/man/stan_sampling_opts.Rd
+++ b/man/stan_sampling_opts.Rd
@@ -59,7 +59,7 @@ stan models. Supported arguments are "rstan" (default) or "cmdstanr".}
 }
 \value{
 A list of arguments to pass to \code{\link[rstan:stanmodel-method-sampling]{rstan::sampling()}} or
-[cmdstanr::sample().
+\code{\link[cmdstanr:model-method-sample]{cmdstanr::sample()}}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #696.

This PR fixes an omission in the documentation of the dots argument of the `stan_sampling_opts()` to add that the dots are passed to `cmdstanr::sample()` too.

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

