### PR TITLE
tweak dev installation guidance in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ install.packages("EpiNow2")
 Install the development version of the package with:
 
 ``` r
-install.packages("EpiNow2", repos = "https://epiforecasts.r-universe.dev")
+install.packages("EpiNow2", repos = c("https://epiforecasts.r-universe.dev", getOption("repos")))
 ```
 
 Alternatively, install the development version of the package with


### PR DESCRIPTION
## Description

Corrects being unable to find dependences when installing the dev version from r-universe. When attempting to follow the instructions on a fresh computer, got errors about being unable to find order 10 dependencies (specific ones lost to overrunning console history with install warning spam).

This PR doesn't close an issue - this is the issue + fix.

## Initial submission checklist

- [ ] No: My PR is based on a package issue and I have explicitly linked it.
- [ ] NA: I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] NA: I have added or updated unit tests where necessary.
- [ ] NA: I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] NA: I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] No: I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.