### PR TITLE
coverage on macos

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -11,7 +11,7 @@ name: test-coverage
 
 jobs:
   test-coverage:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #721.

It changes the test coverage action to run on macos which I've tested to cut the run time by half: https://github.com/epiforecasts/EpiNow2/actions/runs/9963084423

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [ ] ~I have tested my changes locally (using `devtools::test()` and `devtools::check()`).~ NA
- [ ] ~I have added or updated unit tests where necessary.~ NA
- [ ] ~I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).~ NA
- [ ] ~I have followed the established coding standards (and checked using `lintr::lint_package()`).~ NA
- [ ] ~I have added a news item linked to this PR.~ internal change only

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

