### PR TITLE
Additional GP kernels

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 - `epinow()` now returns the "timing" output in a "time difference"" format that is easier to understand and work with. By @jamesmbaazam in #688 and reviewed by @sbfnk.
 - The interface for defining delay distributions has been generalised to also cater for continuous distributions
 - When defining probability distributions these can now be truncated using the `tolerance` argument
-- Ornstein-Uhlenbeck and 5 / 2 matern kernels have been added. By @sbfnk in # and reviewed by @.
+- Ornstein-Uhlenbeck and 5 / 2 Matérn kernels have been added. By @sbfnk in # and reviewed by @.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - `epinow()` now returns the "timing" output in a "time difference"" format that is easier to understand and work with. By @jamesmbaazam in #688 and reviewed by @sbfnk.
 - The interface for defining delay distributions has been generalised to also cater for continuous distributions
 - When defining probability distributions these can now be truncated using the `tolerance` argument
+- Ornstein-Uhlenbeck and 5 / 2 matern kernels have been added. By @sbfnk in # and reviewed by @.
 
 ## Bug fixes
 

--- a/R/create.R
+++ b/R/create.R
@@ -394,9 +394,10 @@ create_gp_data <- function(gp = gp_opts(), data) {
     ls_max = data$t - data$seeding_time - data$horizon,
     alpha_sd = gp$alpha_sd,
     gp_type = data.table::fcase(
-    gp$kernel == "se", 0,
-    gp$kernel == "matern", 1,
-    default = 0
+      is.infinite(gp$matern_order), 0,
+      gp$matern_order == 1/2, 1,
+      gp$matern_order == 3/2, 2,
+      default = 3
     )
   )
 

--- a/R/create.R
+++ b/R/create.R
@@ -395,8 +395,8 @@ create_gp_data <- function(gp = gp_opts(), data) {
     alpha_sd = gp$alpha_sd,
     gp_type = data.table::fcase(
       is.infinite(gp$matern_order), 0,
-      gp$matern_order == 1/2, 1,
-      gp$matern_order == 3/2, 2,
+      gp$matern_order == 1 / 2, 1,
+      gp$matern_order == 3 / 2, 2,
       default = 3
     )
   )

--- a/R/opts.R
+++ b/R/opts.R
@@ -432,6 +432,9 @@ backcalc_opts <- function(prior = c("reports", "none", "infections"),
 #' @param matern_order Numeric, defaults to 3/2. Order of Matern Kernel to use.
 #' Currently the orders 1/2, 3/2, 5/2 and Inf are supported.
 #'
+#' @param matern_type Deprated; Numeric, defaults to 3/2. Order of Matern Kernel
+#'   to use.  Currently the orders 1/2, 3/2, 5/2 and Inf are supported.
+#'
 #' @param basis_prop Numeric, proportion of time points to use as basis
 #' functions. Defaults to 0.2. Decreasing this value results in a decrease in
 #' accuracy but a faster compute time (with increasing it having the first
@@ -460,22 +463,36 @@ gp_opts <- function(basis_prop = 0.2,
                     ls_max = 60,
                     alpha_sd = 0.05,
                     kernel = c("matern", "se", "ou"),
-                    matern_order = 3 / 2) {
+                    matern_order = 3 / 2,
+                    matern_type) {
+  lifecycle::deprecate_warn(
+    "1.6.0", "gp_opts(matern_type)", "gp_opts(matern_order)"
+  )
+  if (!missing(matern_type)) {
+    if (!missing(matern_order) && matern_type == matern_order) {
+      stop(
+        "Incompatible `matern_order` and `matern_type`. ",
+        "Use `matern_order` only."
+      )
+    }
+    matern_order <- matern_type
+  }
+
   kernel <- arg_match(kernel)
   if (kernel == "se") {
     if (!missing(matern_order) && is.finite(matern_order)) {
-      stop("Squared exponential kernel must have matern order unset of `Inf`.")
+      stop("Squared exponential kernel must have matern order unset or `Inf`.")
     }
     matern_order <- Inf
   } else if (kernel == "ou") {
     if (!missing(matern_order) && matern_order != 1 / 2) {
-      stop("Ornstein-Uhlenbeck kernel must have matern order unset of `1 / 2`.")
+      stop("Ornstein-Uhlenbeck kernel must have matern order unset or `1 / 2`.") ## nolint: nonportable_path_linter
     }
     matern_order <- 1 / 2
   } else if (!(is.infinite(matern_order) ||
                  matern_order %in% c(1 / 2, 3 / 2,  5 / 2))) {
     stop(
-      "only the Matern kernels of order `1 / 2`, `3 / 2`, `5 / 2` or `Inf` ",
+      "only the Matern kernels of order `1 / 2`, `3 / 2`, `5 / 2` or `Inf` ", ## nolint: nonportable_path_linter
       "are currently supported"
     )
   }

--- a/R/opts.R
+++ b/R/opts.R
@@ -469,13 +469,13 @@ gp_opts <- function(basis_prop = 0.2,
     matern_order <- Inf
   } else if (kernel == "ou") {
     if (!missing(matern_order) && matern_order != 1 / 2) {
-      stop("Ornstein-Uhlenbeck kernel must have matern order unset of `1/2`.")
+      stop("Ornstein-Uhlenbeck kernel must have matern order unset of `1 / 2`.")
     }
     matern_order <- 1 / 2
   } else if (!(is.infinite(matern_order) ||
-               matern_order %in% c(1 / 2, 3 / 2,  5 / 2))) {
+                 matern_order %in% c(1 / 2, 3 / 2,  5 / 2))) {
     stop(
-      "only the Matern kernels of order 1/2, 3/2, 5/2 or Inf ",
+      "only the Matern kernels of order `1 / 2`, `3 / 2`, `5 / 2` or `Inf` ",
       "are currently supported"
     )
   }

--- a/R/opts.R
+++ b/R/opts.R
@@ -426,13 +426,13 @@ backcalc_opts <- function(prior = c("reports", "none", "infections"),
 #' 'matern_order = Inf'), 3 over 2 oder 5 over 2 Matern kernel ("matern", with
 #' `matern_order = 3/2` (default) or `matern_order = 5/2`, respectively), or
 #' Orstein-Uhlenbeck ("ou", or "matern" with 'matern_order = 1/2'). Defaulting
-#' to the Matern 3 over 2 kernel for a balance of smoothness and
+#' to the Matérn 3 over 2 kernel for a balance of smoothness and
 #' discontinuities.
 #'
-#' @param matern_order Numeric, defaults to 3/2. Order of Matern Kernel to use.
+#' @param matern_order Numeric, defaults to 3/2. Order of Matérn Kernel to use.
 #' Currently the orders 1/2, 3/2, 5/2 and Inf are supported.
 #'
-#' @param matern_type Deprated; Numeric, defaults to 3/2. Order of Matern Kernel
+#' @param matern_type Deprated; Numeric, defaults to 3/2. Order of Matérn Kernel
 #'   to use.  Currently the orders 1/2, 3/2, 5/2 and Inf are supported.
 #'
 #' @param basis_prop Numeric, proportion of time points to use as basis

--- a/R/opts.R
+++ b/R/opts.R
@@ -422,12 +422,15 @@ backcalc_opts <- function(prior = c("reports", "none", "infections"),
 #' the expected standard deviation of the logged Rt.
 #'
 #' @param kernel Character string, the type of kernel required. Currently
-#' supporting the squared exponential kernel ("se") and the 3 over 2 Matern
-#' kernel ("matern", with `matern_type = 3/2`). Defaulting to the Matern 3 over
-#' 2 kernel as discontinuities are expected  in Rt and infections.
+#' supporting the squared exponential kernel ("se", or "matern" with
+#' 'matern_order = Inf'), 3 over 2 oder 5 over 2 Matern kernel ("matern", with
+#' `matern_order = 3/2` (default) or `matern_order = 5/2`, respectively), or
+#' Orstein-Uhlenbeck ("ou", or "matern" with 'matern_order = 1/2'). Defaulting
+#' to the Matern 3 over 2 kernel for a balance of smoothness and
+#' discontinuities.
 #'
-#' @param matern_type Numeric, defaults to 3/2. Type of Matern Kernel to use.
-#' Currently only the Matern 3/2 kernel is supported.
+#' @param matern_order Numeric, defaults to 3/2. Order of Matern Kernel to use.
+#' Currently the orders 1/2, 3/2, 5/2 and Inf are supported.
 #'
 #' @param basis_prop Numeric, proportion of time points to use as basis
 #' functions. Defaults to 0.2. Decreasing this value results in a decrease in
@@ -457,7 +460,19 @@ gp_opts <- function(basis_prop = 0.2,
                     ls_max = 60,
                     alpha_sd = 0.05,
                     kernel = c("matern_3/2", "se"),
-                    matern_type = 3 / 2) {
+                    matern_order = 3 / 2) {
+  if (kernel == "se") {
+    matern_order <- Inf
+  } else if (kernel == "ou") {
+    matern_order <- 1 / 2
+  } else if (!(is.infinite(matern_order) ||
+               matern_order %in% c(1 / 2, 3 / 2,  5 / 2))) {
+    stop(
+      "only the Matern kernels of order 1/2, 3/2, 5/2 or Inf ",
+      "are currently supported"
+    )
+  }
+
   gp <- list(
     basis_prop = basis_prop,
     boundary_scale = boundary_scale,
@@ -467,12 +482,9 @@ gp_opts <- function(basis_prop = 0.2,
     ls_max = ls_max,
     alpha_sd = alpha_sd,
     kernel = arg_match(kernel),
-    matern_type = matern_type
+    matern_order = matern_order
   )
 
-  if (gp$matern_type != 3 / 2) {
-    stop("only the Matern 3/2 kernel is currently supported") # nolint
-  }
   attr(gp, "class") <- c("gp_opts", class(gp))
   return(gp)
 }

--- a/R/opts.R
+++ b/R/opts.R
@@ -459,11 +459,18 @@ gp_opts <- function(basis_prop = 0.2,
                     ls_min = 0,
                     ls_max = 60,
                     alpha_sd = 0.05,
-                    kernel = c("matern_3/2", "se"),
+                    kernel = c("matern", "se", "ou"),
                     matern_order = 3 / 2) {
+  kernel <- arg_match(kernel)
   if (kernel == "se") {
+    if (!missing(matern_order) && is.finite(matern_order)) {
+      stop("Squared exponential kernel must have matern order unset of `Inf`.")
+    }
     matern_order <- Inf
   } else if (kernel == "ou") {
+    if (!missing(matern_order) && matern_order != 1 / 2) {
+      stop("Ornstein-Uhlenbeck kernel must have matern order unset of `1/2`.")
+    }
     matern_order <- 1 / 2
   } else if (!(is.infinite(matern_order) ||
                matern_order %in% c(1 / 2, 3 / 2,  5 / 2))) {
@@ -481,7 +488,7 @@ gp_opts <- function(basis_prop = 0.2,
     ls_min = ls_min,
     ls_max = ls_max,
     alpha_sd = alpha_sd,
-    kernel = arg_match(kernel),
+    kernel = kernel,
     matern_order = matern_order
   )
 

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -24,7 +24,9 @@ transformed data{
   int ot = t - seeding_time - horizon;  // observed time
   int ot_h = ot + horizon;  // observed time + forecast horizon
   // gaussian process
-  int noise_terms = setup_noise(ot_h, t, horizon, estimate_r, stationary, future_fixed, fixed_from);
+  int noise_terms = setup_noise(
+    ot_h, t, horizon, estimate_r, stationary, future_fixed, fixed_from
+  );
   matrix[noise_terms, M] PHI = setup_gp(M, L, noise_terms);  // basis function
   // Rt
   real r_logmean = log(r_mean^2 / sqrt(r_sd^2 + r_mean^2));

--- a/inst/stan/functions/gaussian_process.stan
+++ b/inst/stan/functions/gaussian_process.stan
@@ -2,28 +2,31 @@
 // see here for details: https://arxiv.org/pdf/2004.11408.pdf
 real lambda(real L, int m) {
   real lam;
-  lam = ((m*pi())/(2*L))^2;
+  lam = ((m * pi())/(2 * L))^2;
   return lam;
 }
+
 // eigenfunction for approximate hilbert space gp
 // see here for details: https://arxiv.org/pdf/2004.11408.pdf
 vector phi(real L, int m, vector x) {
   vector[rows(x)] fi;
-  fi = 1/sqrt(L) * sin(m*pi()/(2*L) * (x+L));
+  fi = 1/sqrt(L) * sin(m * pi()/(2 * L) * (x + L));
   return fi;
 }
+
 // spectral density of the exponential quadratic kernal
 real spd_se(real alpha, real rho, real w) {
   real S;
-  S = (alpha^2) * sqrt(2*pi()) * rho * exp(-0.5*(rho^2)*(w^2));
+  S = (alpha^2) * sqrt(2 * pi()) * rho * exp(-0.5 * (rho^2) * (w^2));
   return S;
 }
 // spectral density of the Matern 3/2 kernel
 real spd_matern(real alpha, real rho, real w) {
   real S;
-  S = 4*alpha^2 * (sqrt(3)/rho)^3 * 1/((sqrt(3)/rho)^2 + w^2)^2;
+  S = 4 * alpha^2 * (sqrt(3) / rho)^3 * 1 / ((sqrt(3) / rho)^2 + w^2)^2;
   return S;
 }
+
 // setup gaussian process noise dimensions
 int setup_noise(int ot_h, int t, int horizon, int estimate_r,
                 int stationary, int future_fixed, int fixed_from) {
@@ -44,6 +47,7 @@ matrix setup_gp(int M, real L, int dimension) {
   }
   return(PHI);
 }
+
 // update gaussian process using spectral densities
 vector update_gp(matrix PHI, int M, real L, real alpha,
                  real rho, vector eta, int type) {
@@ -57,7 +61,7 @@ vector update_gp(matrix PHI, int M, real L, real alpha,
     for(m in 1:M){
       diagSPD[m] =  sqrt(spd_se(alpha, unit_rho, sqrt(lambda(L, m))));
     }
-  }else if (type == 1) {
+  } else if (type == 1) {
     for(m in 1:M){
       diagSPD[m] =  sqrt(spd_matern(alpha, unit_rho, sqrt(lambda(L, m))));
     }
@@ -66,6 +70,7 @@ vector update_gp(matrix PHI, int M, real L, real alpha,
   noise = noise + PHI[,] * SPD_eta;
   return(noise);
 }
+
 // priors for gaussian process
 void gaussian_process_lp(real rho, real alpha, vector eta,
                          real ls_meanlog, real ls_sdlog,

--- a/inst/stan/functions/rt.stan
+++ b/inst/stan/functions/rt.stan
@@ -27,7 +27,7 @@ vector update_Rt(int t, real log_R, vector noise, array[] int bps,
       if (t > gp_n) {
         gp[(gp_n + 1):t] = rep_vector(noise[gp_n], t - gp_n);
       }
-    }else{
+    } else {
       gp[2:(gp_n + 1)] = noise;
       gp = cumulative_sum(gp);
     }

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -13,7 +13,8 @@ gp_opts(
   ls_max = 60,
   alpha_sd = 0.05,
   kernel = c("matern", "se", "ou"),
-  matern_order = 3/2
+  matern_order = 3/2,
+  matern_type = 3/2
 )
 }
 \arguments{
@@ -56,6 +57,9 @@ discontinuities.}
 
 \item{matern_order}{Numeric, defaults to 3/2. Order of Matern Kernel to use.
 Currently the orders 1/2, 3/2, 5/2 and Inf are supported.}
+
+\item{matern_type}{Deprated; Numeric, defaults to 3/2. Order of Matern Kernel
+to use.  Currently the orders 1/2, 3/2, 5/2 and Inf are supported.}
 }
 \value{
 A \verb{<gp_opts>} object of settings defining the Gaussian process

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -12,7 +12,7 @@ gp_opts(
   ls_min = 0,
   ls_max = 60,
   alpha_sd = 0.05,
-  kernel = c("matern_3/2", "se"),
+  kernel = c("matern", "se", "ou"),
   matern_order = 3/2
 )
 }

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -14,7 +14,7 @@ gp_opts(
   alpha_sd = 0.05,
   kernel = c("matern", "se", "ou"),
   matern_order = 3/2,
-  matern_type = 3/2
+  matern_type
 )
 }
 \arguments{
@@ -52,13 +52,13 @@ supporting the squared exponential kernel ("se", or "matern" with
 'matern_order = Inf'), 3 over 2 oder 5 over 2 Matern kernel ("matern", with
 \code{matern_order = 3/2} (default) or \code{matern_order = 5/2}, respectively), or
 Orstein-Uhlenbeck ("ou", or "matern" with 'matern_order = 1/2'). Defaulting
-to the Matern 3 over 2 kernel for a balance of smoothness and
+to the Matérn 3 over 2 kernel for a balance of smoothness and
 discontinuities.}
 
-\item{matern_order}{Numeric, defaults to 3/2. Order of Matern Kernel to use.
+\item{matern_order}{Numeric, defaults to 3/2. Order of Matérn Kernel to use.
 Currently the orders 1/2, 3/2, 5/2 and Inf are supported.}
 
-\item{matern_type}{Deprated; Numeric, defaults to 3/2. Order of Matern Kernel
+\item{matern_type}{Deprated; Numeric, defaults to 3/2. Order of Matérn Kernel
 to use.  Currently the orders 1/2, 3/2, 5/2 and Inf are supported.}
 }
 \value{

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -13,7 +13,7 @@ gp_opts(
   ls_max = 60,
   alpha_sd = 0.05,
   kernel = c("matern_3/2", "se"),
-  matern_type = 3/2
+  matern_order = 3/2
 )
 }
 \arguments{
@@ -47,12 +47,15 @@ magnitude parameter of the Gaussian process kernel. Should be approximately
 the expected standard deviation of the logged Rt.}
 
 \item{kernel}{Character string, the type of kernel required. Currently
-supporting the squared exponential kernel ("se") and the 3 over 2 Matern
-kernel ("matern", with \code{matern_type = 3/2}). Defaulting to the Matern 3 over
-2 kernel as discontinuities are expected  in Rt and infections.}
+supporting the squared exponential kernel ("se", or "matern" with
+'matern_order = Inf'), 3 over 2 oder 5 over 2 Matern kernel ("matern", with
+\code{matern_order = 3/2} (default) or \code{matern_order = 5/2}, respectively), or
+Orstein-Uhlenbeck ("ou", or "matern" with 'matern_order = 1/2'). Defaulting
+to the Matern 3 over 2 kernel for a balance of smoothness and
+discontinuities.}
 
-\item{matern_type}{Numeric, defaults to 3/2. Type of Matern Kernel to use.
-Currently only the Matern 3/2 kernel is supported.}
+\item{matern_order}{Numeric, defaults to 3/2. Order of Matern Kernel to use.
+Currently the orders 1/2, 3/2, 5/2 and Inf are supported.}
 }
 \value{
 A \verb{<gp_opts>} object of settings defining the Gaussian process

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -105,6 +105,14 @@ test_that("estimate_infections works without setting a generation time", {
   expect_equal(exp(combined$growth_rate), combined$R)
 })
 
+test_that("estimate_infections works with different kernels", {
+  skip_on_cran()
+  test_estimate_infections(reported_cases, gp = gp_opts(kernel = "se"))
+  test_estimate_infections(reported_cases, gp = gp_opts(kernel = "ou"))
+  test_estimate_infections(reported_cases, gp = gp_opts(matern_order = 5 / 2))
+  expect_error(gp_opts(matern_order = 4))
+})
+
 test_that("estimate_infections fails as expected when given a very short timeout", {
   skip_on_cran()
   expect_error(output <- capture.output(suppressMessages(

--- a/vignettes/gaussian_process_implementation_details.Rmd
+++ b/vignettes/gaussian_process_implementation_details.Rmd
@@ -41,7 +41,7 @@ k(t,t') = k(|t - t'|) = k(\Delta t)
 
 with the following choices available for the kernel $k$
 
-## Matern 3/2 covariance kernel (the default)
+## Matérn 3/2 covariance kernel (the default)
 
 \begin{equation}
 k(\Delta t) = \alpha \left( 1 + \frac{\sqrt{3} \Delta t}{l} \right) \exp \left( - \frac{\sqrt{3} \Delta t}{l}\right)
@@ -55,13 +55,13 @@ with $l>0$ and $\alpha > 0$ the length scale and magnitude, respectively, of the
 k(\Delta t) = \alpha \exp \left( - \frac{1}{2} \frac{(\Delta t^2)}{l^2} \right)
 \end{equation}
 
-## Ornstein-Uhlenbeck (Matern 1/2) kernel
+## Ornstein-Uhlenbeck (Matérn 1/2) kernel
 
 \begin{equation}
 k(\Delta t) = \alpha \exp{\left( - \frac{\Delta t}{2 l^2}  \right)}
 \end{equation}
 
-## Matern 5/2 covariance kernel
+## Matérn 5/2 covariance kernel
 
 \begin{equation}
 k(\Delta t) = \alpha \left( 1 + \frac{\sqrt{5} \Delta t}{l} + \frac{5}{3} \left(\frac{\Delta t}{l} \right)^2 \right) \exp \left( - \frac{\sqrt{5} \Delta t}{l}\right)
@@ -93,7 +93,7 @@ where $L$ is a positive number termed boundary condition, and $\beta_{j}$ are re
 \beta_j \sim \mathcal{Normal}(0, 1)
 \end{equation}
 
-The function $S_k(x)$ is the spectral density relating to a particular covariance function $k$. In the case of the Matern 3/2 kernel (the default in `EpiNow2`) this is given by
+The function $S_k(x)$ is the spectral density relating to a particular covariance function $k$. In the case of the Matérn 3/2 kernel (the default in `EpiNow2`) this is given by
 
 \begin{equation}
 S_k(x) = 4 \alpha^2 \left( \frac{\sqrt{3}}{\rho}\right)^3 \left(\left( \frac{\sqrt{3}}{\rho} \right)^2 + w^2 \right)^{-2}

--- a/vignettes/gaussian_process_implementation_details.Rmd
+++ b/vignettes/gaussian_process_implementation_details.Rmd
@@ -39,17 +39,32 @@ In our case as set out above, we have
 k(t,t') = k(|t - t'|) = k(\Delta t)
 \end{equation}
 
-where by default $k$ is a Matern 3/2 covariance kernel,
+with the following choices available for the kernel $k$
+
+## Matern 3/2 covariance kernel (the default)
 
 \begin{equation}
 k(\Delta t) = \alpha \left( 1 + \frac{\sqrt{3} \Delta t}{l} \right) \exp \left( - \frac{\sqrt{3} \Delta t}{l}\right)
 \end{equation}
 
 with $l>0$ and $\alpha > 0$ the length scale and magnitude, respectively, of the kernel.
-Alternatively, a squared exponential kernel can be chosen to constrain the GP to be smoother.
+
+## Squared exponential kernel
 
 \begin{equation}
 k(\Delta t) = \alpha \exp \left( - \frac{1}{2} \frac{(\Delta t^2)}{l^2} \right)
+\end{equation}
+
+## Ornstein-Uhlenbeck (Matern 1/2) kernel
+
+\begin{equation}
+k(\Delta t) = \alpha \exp{\left( - \frac{\Delta t}{2 l^2}  \right)}
+\end{equation}
+
+## Matern 5/2 covariance kernel
+
+\begin{equation}
+k(\Delta t) = \alpha \left( 1 + \frac{\sqrt{5} \Delta t}{l} + \frac{5}{3} \left(\frac{\Delta t}{l} \right)^2 \right) \exp \left( - \frac{\sqrt{5} \Delta t}{l}\right)
 \end{equation}
 
 # Hilbert space approximation


### PR DESCRIPTION
## Description

This PR introduces additional GP kernels: Ornstein-Uhlenbeck and Matérn 5 / 2, for more modelling choices especially for forecasting.

Someone would have to check the maths is correct before this is merged.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] ~My PR is based on a package issue and I have explicitly linked it.~ not fixing issue but an extension of functionality
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

