### PR TITLE
dependencies: NA for render actions

### DIFF
--- a/.github/workflows/render-EpiNow2.yaml
+++ b/.github/workflows/render-EpiNow2.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: NA
           extra-packages: local::.
 
       - name: Render vignette

--- a/.github/workflows/render-epinow.yaml
+++ b/.github/workflows/render-epinow.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: NA
           extra-packages: local::.
 
       - name: Render vignette

--- a/.github/workflows/render-estimate_infections_options.yaml
+++ b/.github/workflows/render-estimate_infections_options.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: NA
           extra-packages: local::.
 
       - name: Render vignette

--- a/.github/workflows/render-estimate_infections_workflow.yaml
+++ b/.github/workflows/render-estimate_infections_workflow.yaml
@@ -31,6 +31,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          dependencies: NA
           extra-packages: local::.
 
       - name: Render vignette


### PR DESCRIPTION
all the render Rmd actions are failing because they can't install `cmdstanr`. I think this will fix it.