### PR TITLE
Issue 824: delete sentence about warning if non-zero first element

### DIFF
--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -65,7 +65,6 @@ Users can also pass a non-parametric delay distribution vector using the `NonPar
 for both the generation interval and reporting delays. It is important to note that if doing so,
 both delay distributions are 0-indexed, meaning the first element corresponds to the probability mass
 at day 0 of an individual's infection. Because the discretised renewal equation doesn't support mass on day 0, the generation interval should be passed in as a 0-indexed vector with a mass of zero on day 0. 
-If this is not the case, a warning will indicate that the vector is being left-truncated and renormalized.
 
 ```{r}
 example_non_parametric_gi <-  NonParametric(pmf = c(0, 0.3, 0.5, 0.2))


### PR DESCRIPTION
## Description

This PR closes #824, as discussed https://github.com/epiforecasts/EpiNow2/pull/799#discussion_r1790541834

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X]  My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [X] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

