### PR TITLE
Install `future` and `future.apply` to fix `R CMD CHECK`

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,6 +64,8 @@ jobs:
             rcmdcheck
             stan-dev/cmdstanr
             testthat
+            future
+            future.apply
 
       - name: Install cmdstan
         if: runner.os != 'Windows'

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -38,6 +38,8 @@ jobs:
             covr
             stan-dev/cmdstanr
             testthat
+            future
+            future.apply
 
       - name: Install cmdstan
         if: runner.os != 'Windows'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,5 @@
 # EpiNow2 (development version)
 
-## Package
-
-- The `future` and `future.apply` packages are now installed in the `R CMD CHECK` workflow to ensure that the `test-coverage` workflow runs without errors. By @jamesmbaazam in #827 and reviewed by @<REVIEWER>.
-
 # EpiNow2 1.6.0
 
 A release that introduces model improvements to the Gaussian Process models, alongside a number of other improvements and bug fixes.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # EpiNow2 (development version)
 
+## Package
+
+- The `future` and `future.apply` packages are now installed in the `R CMD CHECK` workflow to ensure that the `test-coverage` workflow runs without errors. By @jamesmbaazam in #827 and reviewed by @<REVIEWER>.
+
 # EpiNow2 1.6.0
 
 A release that introduces model improvements to the Gaussian Process models, alongside a number of other improvements and bug fixes.


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #826. Since #798, the `future` and `future.apply` packages were made optional but `future` is required to run the tests, so `R CMD CHECK` has been failing on `main` and subsequent PRs (#774, #825). This PR fixes the failing `R CMD CHECK` on `main` by installing `future`. It additionally installs `future.apply` so that it can be tested instead of using `lapply()`.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [x] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

