### PR TITLE
Fix `plot.estimate_secondary()` for `forecast_secondary()` output

### DIFF
--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -369,7 +369,7 @@ plot.estimate_secondary <- function(x, primary = FALSE,
                                     from = NULL, to = NULL,
                                     new_obs = NULL,
                                     ...) {
-  predictions <- data.table::copy(x$predictions)[!is.na(secondary)]
+  predictions <- data.table::copy(x$predictions)
 
   if (!is.null(new_obs)) {
     new_obs <- data.table::as.data.table(new_obs)


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #702 by reverting a change that removed `NA` `secondary` rows, thereby dropping the data needed to plot forecast "secondary" outcomes.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

