### PR TITLE
restore alpha prior SD to 0.05

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Model changes
 
 - A bug in the spectral densities of Matern kernels of order other than 3/2 has been fixed and the vignette updated accordingly. By @sbfnk in #835 and reviewed by @seabbs.
-- Changed the prior on the (square root of the) magnitude alpha of the Gaussian Process back to HalfNormal(0, 0.05) based on user feedback of unexpected results. By @sbfnk in #PR and reviewed by.
+- Changed the prior on the (square root of the) magnitude alpha of the Gaussian Process back to HalfNormal(0, 0.05) based on user feedback of unexpected results. By @sbfnk in #840 and reviewed by @jamesmbaazam.
 
 ## Package changes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Model changes
 
 - A bug in the spectral densities of Matern kernels of order other than 3/2 has been fixed and the vignette updated accordingly. By @sbfnk in #835 and reviewed by @seabbs.
+- Changed the prior on the (square root of the) magnitude alpha of the Gaussian Process back to HalfNormal(0, 0.05) based on user feedback of unexpected results. By @sbfnk in #PR and reviewed by.
 
 ## Package changes
 
@@ -25,7 +26,7 @@ A release that introduces model improvements to the Gaussian Process models, alo
 - When defining probability distributions these can now be truncated using the `tolerance` argument
 - Ornstein-Uhlenbeck and 5 / 2 Matérn kernels have been added. By @sbfnk in #741 and reviewed by @seabbs.
 - Gaussian processes have been vectorised, leading to some speed gains 🚀 , and the `gp_opts()` function has gained three more options, "periodic", "ou",  and "se", to specify periodic and linear kernels respectively. By @seabbs in #742 and reviewed by @jamesmbaazam.
-- Prior predictive checks have been used to update the following priors: the prior on the magnitude of the Gaussian process (from HalfNormal(0, 1) to HalfNormal(0, 0.1)), and the prior on the overdispersion (from 1 / HalfNormal(0, 1)^2 to 1 / HalfNormal(0, 0.25)). In the user-facing API, this is a change in default values of the `sd` of `phi` in `obs_opts()` from 1 to 0.25. By @seabbs in #742 and reviewed by @jamesmbaazam.
+- Prior predictive checks have been used to update the following priors: the prior on the magnitude of the Gaussian process (from HalfNormal(0, 0.05)^2 to HalfNormal(0, 0.01)^2), and the prior on the overdispersion (from 1 / HalfNormal(0, 1)^2 to 1 / HalfNormal(0, 0.25)). In the user-facing API, this is a change in default values of the `sd` of `phi` in `obs_opts()` from 1 to 0.25. By @seabbs in #742 and reviewed by @jamesmbaazam.
 - The default stan control options have been updated from `list(adapt_delta = 0.95, max_treedepth = 15)` to `list(adapt_delta = 0.9, max_treedepth = 12)` due to improved performance and to reduce the runtime of the default parameterisations. By @seabbs in #742 and reviewed by @jamesmbaazam.
 - Initialisation has been simplified by sampling directly from the priors, where possible, rather than from a constrained space. By @seabbs in #742 and reviewed by @jamesmbaazam.
 - Unnecessary normalisation of delay priors has been removed. By @seabbs in #742 and reviewed by @jamesmbaazam.

--- a/R/opts.R
+++ b/R/opts.R
@@ -458,7 +458,7 @@ backcalc_opts <- function(prior = c("reports", "none", "infections"),
 #' deviation of the Gaussian process (logged Rt in case of the renewal model,
 #' logged infections in case of the nonmechanistic model).
 #'
-#' @param alpha_sd Numeric, defaults to 0.1. The standard deviation of the
+#' @param alpha_sd Numeric, defaults to 0.05. The standard deviation of the
 #' magnitude parameter of the Gaussian process kernel. Can be tuned to adjust
 #' how far alpha is allowed to deviate form its prior mean (`alpha_mean`).
 #'
@@ -509,7 +509,7 @@ gp_opts <- function(basis_prop = 0.2,
                     ls_min = 0,
                     ls_max = 60,
                     alpha_mean = 0,
-                    alpha_sd = 0.01,
+                    alpha_sd = 0.05,
                     kernel = c("matern", "se", "ou", "periodic"),
                     matern_order = 3 / 2,
                     matern_type,

--- a/man/gp_opts.Rd
+++ b/man/gp_opts.Rd
@@ -12,7 +12,7 @@ gp_opts(
   ls_min = 0,
   ls_max = 60,
   alpha_mean = 0,
-  alpha_sd = 0.01,
+  alpha_sd = 0.05,
   kernel = c("matern", "se", "ou", "periodic"),
   matern_order = 3/2,
   matern_type,
@@ -50,7 +50,7 @@ of the Gaussian process kernel. Should be approximately the expected standard
 deviation of the Gaussian process (logged Rt in case of the renewal model,
 logged infections in case of the nonmechanistic model).}
 
-\item{alpha_sd}{Numeric, defaults to 0.1. The standard deviation of the
+\item{alpha_sd}{Numeric, defaults to 0.05. The standard deviation of the
 magnitude parameter of the Gaussian process kernel. Can be tuned to adjust
 how far alpha is allowed to deviate form its prior mean (\code{alpha_mean}).}
 

--- a/tests/testthat/test-create_gp_data.R
+++ b/tests/testthat/test-create_gp_data.R
@@ -11,7 +11,7 @@ test_that("create_gp_data returns correct default values when GP is disabled", {
   expect_equal(gp_data$ls_sdlog, convert_to_logsd(21, 7))
   expect_equal(gp_data$ls_min, 0)
   expect_equal(gp_data$ls_max, 3.54, tolerance = 0.01)
-  expect_equal(gp_data$alpha_sd, 0.01)
+  expect_equal(gp_data$alpha_sd, 0.05)
   expect_equal(gp_data$gp_type, 2)  # Default to Matern
   expect_equal(gp_data$nu, 3 / 2)
   expect_equal(gp_data$w0, 1.0)

--- a/tests/testthat/test-gp_opts.R
+++ b/tests/testthat/test-gp_opts.R
@@ -6,7 +6,7 @@ test_that("gp_opts returns correct default values", {
   expect_equal(gp$ls_sd, 7)
   expect_equal(gp$ls_min, 0)
   expect_equal(gp$ls_max, 60)
-  expect_equal(gp$alpha_sd, 0.01)
+  expect_equal(gp$alpha_sd, 0.05)
   expect_equal(gp$kernel, "matern")
   expect_equal(gp$matern_order, 3 / 2)
   expect_equal(gp$w0, 1.0)


### PR DESCRIPTION
## Description

This PR closes #834.

Still happy to review/reconsider if other values might work better.

I think I've got the squares / square roots right (and fixed them in the old news item) but may have got confused.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

