### PR TITLE
use github version of allcontributors

### DIFF
--- a/.github/workflows/render-readme.yaml
+++ b/.github/workflows/render-readme.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          packages: any::rmarkdown, any::allcontributors
+          packages: any::rmarkdown, ropensci/allcontributors
 
       - name: Update contributors
         if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
Current CRAN version of allcontributors leads to CRAN check failures because the URL has changed but this isn't reflected yet in the CRAN version. This PR updates it to the dev version which will fix this issue for the time being.