### PR TITLE
Fix initial growth

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 ## Model changes
 
-- A bug was fixed where the initial growth was never estimated (i.e. the prior mean was always zero). By @sbfnk in # and reviewed by @.
+- A bug was fixed where the initial growth was never estimated (i.e. the prior mean was always zero). By @sbfnk in #853 and reviewed by @seabbs.
 
 # EpiNow2 1.6.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # EpiNow2 (development version)
 
+## Model changes
+
+- A bug was fixed where the initial growth was never estimated (i.e. the prior mean was always zero). By @sbfnk in # and reviewed by @.
+
 # EpiNow2 1.6.1
 
 ## Model changes

--- a/R/create.R
+++ b/R/create.R
@@ -561,7 +561,7 @@ create_stan_data <- function(data, seeding_time,
   if (stan_data$seeding_time > 1 && nrow(first_week) > 1) {
     safe_lm <- purrr::safely(stats::lm)
     stan_data$prior_growth <- safe_lm(log(confirm) ~ t,
-      stan_data = first_week
+      data = first_week
     )[[1]]
     stan_data$prior_growth <- ifelse(is.null(stan_data$prior_growth), 0,
       stan_data$prior_growth$coefficients[2]


### PR DESCRIPTION
## Description

This PR fixes a bug whereby the initial growth was never estimated because of a misnamed argument wrapped inside a `purrr::safely` call. Not a big deal probably, as this is poorly identified anyway (highly anti-correlated with the number of initial infections) and has a comparatively wide prior sd.

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

