### PR TITLE
Replace "tolerance" with "default_cdf_cutoff" in message

### DIFF
--- a/R/opts.R
+++ b/R/opts.R
@@ -1098,7 +1098,7 @@ apply_default_cdf_cutoff <- function(dist, default_cdf_cutoff, cdf_cutoff_set) {
         "i" = "Unconstrained distributon passed as a delay. ",
         "i" = "Constraining with default CDF cutoff {default_cdf_cutoff}.",
         "i" = "To silence this message, specify delay distributions
-      with {.var max} or {.var tolerance}."
+      with {.var max} or {.var default_cdf_cutoff}."
       )
     )
     #nolint end


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #860 by replacing "tolerance" with "default_cdf_cutoff" in a message because it was a mistake.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

