### PR TITLE
Remove `...` args from `estimate_secondary()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,7 @@
 ## Documentation
 
 - Brought the docs on `alpha_sd` up to date with the code change from prior PR #853. By @zsusswein in #862 and reviewed by @jamesmbaazam.
+- The `...` argument in `estimate_secondary()` has been removed because it was not used. By @jamesmbaazam in #894 and reviewed by @.
 
 # EpiNow2 1.6.1
 

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -58,8 +58,6 @@
 #' @param verbose Logical, should model fitting progress be returned. Defaults
 #' to [interactive()].
 #'
-#' @param ... Additional parameters to pass to [stan_opts()].
-#'
 #' @return A list containing: `predictions` (a `<data.frame>` ordered by date
 #' with the primary, and secondary observations, and a summary of the model
 #' estimated secondary observations), `posterior` which contains a summary of
@@ -162,7 +160,6 @@ estimate_secondary <- function(data,
                                model = NULL,
                                weigh_delay_priors = FALSE,
                                verbose = interactive(),
-                               ...,
                                reports) {
   # Deprecate reported_cases in favour of data
   if (!missing(reports)) {

--- a/man/estimate_secondary.Rd
+++ b/man/estimate_secondary.Rd
@@ -20,7 +20,6 @@ estimate_secondary(
   model = NULL,
   weigh_delay_priors = FALSE,
   verbose = interactive(),
-  ...,
   reports
 )
 }
@@ -90,8 +89,6 @@ parameters.}
 
 \item{verbose}{Logical, should model fitting progress be returned. Defaults
 to \code{\link[=interactive]{interactive()}}.}
-
-\item{...}{Additional parameters to pass to \code{\link[=stan_opts]{stan_opts()}}.}
 
 \item{reports}{Deprecated; use \code{data} instead.}
 }


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #869.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

