### PR TITLE
skip future check on CRAN

### DIFF
--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -16,4 +16,6 @@ if (identical(Sys.getenv("NOT_CRAN"), "true")) {
   }
 }
 
-withr::defer(future::plan("sequential"), teardown_env())
+if (requireNamespace("future", quietly = TRUE)) {
+  withr::defer(future::plan("sequential"), teardown_env())
+}

--- a/tests/testthat/test-setup_future.R
+++ b/tests/testthat/test-setup_future.R
@@ -1,4 +1,5 @@
-reported_cases <- data.frame(region = c("test", "boo"))
+skip_on_cran()
+sreported_cases <- data.frame(region = c("test", "boo"))
 futile.logger::flog.threshold("FATAL")
 
 test_that("setup_future runs without error", {

--- a/tests/testthat/test-setup_future.R
+++ b/tests/testthat/test-setup_future.R
@@ -1,5 +1,5 @@
 skip_on_cran()
-sreported_cases <- data.frame(region = c("test", "boo"))
+reported_cases <- data.frame(region = c("test", "boo"))
 futile.logger::flog.threshold("FATAL")
 
 test_that("setup_future runs without error", {


### PR DESCRIPTION
We're seeing some test failures with the check as CRAN because `{future}` (a suggested package) is missing. Perhaps this was previously pulled in as a lower level dependency and is no more due to a change in one of the dependent packages?

With this PR the check of `setup_future()` is skipped on CRAN - it remains to be seen if any other test fails without `{future}`.