### PR TITLE
update touchstone config to noble

### DIFF
--- a/touchstone/config.json
+++ b/touchstone/config.json
@@ -2,5 +2,5 @@
 
     "os": "ubuntu-latest",
     "r": "release",
-    "rspm": "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"
+    "rspm": "https://packagemanager.rstudio.com/cran/__linux__/noble/latest"
 }


### PR DESCRIPTION
ubuntu-latest has been moved to 24.04.1. This updates the touchstone config accordingly.