### PR TITLE
Remove remaining use of adapt delta in docs

### DIFF
--- a/vignettes/EpiNow2.Rmd
+++ b/vignettes/EpiNow2.Rmd
@@ -132,7 +132,7 @@ estimates <- epinow(
   generation_time = gt_opts(example_generation_time),
   delays = delay_opts(example_incubation_period + reporting_delay),
   rt = rt_opts(prior = LogNormal(mean = 2, sd = 0.2)),
-  stan = stan_opts(cores = 4, control = list(adapt_delta = 0.99)),
+  stan = stan_opts(cores = 4),
   verbose = interactive()
 )
 names(estimates)

--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -95,7 +95,7 @@ estimates <- epinow(
   generation_time = gt_opts(example_generation_time),
   delays = delay_opts(example_incubation_period + reporting_delay),
   rt = rt_opts(prior = LogNormal(mean = 2, sd = 0.2)),
-  stan = stan_opts(cores = 4, control = list(adapt_delta = 0.99)),
+  stan = stan_opts(cores = 4, control = list(adapt_delta = 0.9)),
   verbose = interactive()
 )
 names(estimates)

--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -95,7 +95,7 @@ estimates <- epinow(
   generation_time = gt_opts(example_generation_time),
   delays = delay_opts(example_incubation_period + reporting_delay),
   rt = rt_opts(prior = LogNormal(mean = 2, sd = 0.2)),
-  stan = stan_opts(cores = 4, control = list(adapt_delta = 0.9)),
+  stan = stan_opts(cores = 4),
   verbose = interactive()
 )
 names(estimates)


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

Not related to an issue. This PR removes an outstanding use of `adapt_delta` in the user facing docs. Dropping it down from the custom setting to the default  I see a 2 times speed up. However for every 5 runs or so I see one with a few divergent transition. I don't think this is an issue

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

