### PR TITLE
fix final period estimation when shifting cases

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 - The Gaussian Process lengthscale is now scaled internally by half the length of the time series. By @sbfnk in #890 and reviewed by #seabbs.
 - A bug was fixed where `plot.dist_spec()` wasn't throwing an informative error due to an incomplete check for the max of the specified delay. By @jamesmbaazam in #858 and reviewed by @.
 - Updated the early dynamics calculation to estimate growth from the initial reproduction number instead of a separate linear model. Also changed the prior calculation for initial infections to be a scaling factor of early case numbers adjusted by the growth estimate, instead a true number of initial infections. By @sbfnk in #923 (with initial exploration in #903) and reviewed by @seabbs and @SamuelBrand1. 
+- A bug was fixed in the non-mechanistic model where the final period could have discontinuities. By @sbfnk in # and reviewed by # .
 
 ## Package changes
 

--- a/man/create_shifted_cases.Rd
+++ b/man/create_shifted_cases.Rd
@@ -53,12 +53,13 @@ shift <- 7
 horizon <- 7
 smoothing_window <- 14
 ## add NAs for horizon
-cases <- create_clean_reported_cases(example_confirmed, horizon = horizon)
+cases <- create_clean_reported_cases(example_confirmed[1:30])
+cases <- add_horizon(cases, horizon)
 ## add zeroes initially
 cases <- data.table::rbindlist(list(
    data.table::data.table(
      date = seq(
-       min(cases$date) - smoothing_window,
+       min(cases$date) - 10,
        min(cases$date) - 1,
        by = "days"
      ),

--- a/tests/testthat/test-create_shifted_cases.R
+++ b/tests/testthat/test-create_shifted_cases.R
@@ -1,3 +1,4 @@
+horizon <- 7
 cases <- create_clean_reported_cases(example_confirmed[1:30])
 cases <- add_horizon(cases, horizon)
 ## add zeroes initially
@@ -14,7 +15,7 @@ cases <- data.table::rbindlist(list(
 ))
 
 test_that("create_shifted_cases does not create discontinuities with exponential growth", {
-  result <- create_shifted_cases(cases, 7, 14, 7)
+  result <- create_shifted_cases(cases, 7, 14, horizon)
   expect_s3_class(result, "data.table")
   expect_true(all(diff(result$confirm) > 0))
 })

--- a/tests/testthat/test-create_shifted_cases.R
+++ b/tests/testthat/test-create_shifted_cases.R
@@ -1,0 +1,20 @@
+cases <- create_clean_reported_cases(example_confirmed[1:30])
+cases <- add_horizon(cases, horizon)
+## add zeroes initially
+cases <- data.table::rbindlist(list(
+  data.table::data.table(
+    date = seq(
+      min(cases$date) - 10,
+      min(cases$date) - 1,
+      by = "days"
+    ),
+    confirm = 0, breakpoint = 0
+  ),
+  cases
+))
+
+test_that("create_shifted_cases does not create discontinuities with exponential growth", {
+  result <- create_shifted_cases(cases, 7, 14, 7)
+  expect_s3_class(result, "data.table")
+  expect_true(all(diff(result$confirm) > 0))
+})


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #948 and adds a regression test.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [x] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

