### PR TITLE
use safe negative binomial rng

### DIFF
--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -189,6 +189,29 @@ vector report_log_lik(array[] int cases, vector reports,
   return(log_lik);
 }
 
+
+/**
+ * Custom safe version of the negative binomial sampler
+ *
+ * This function generates random samples of the negative binomial distribution
+ * whilst avoiding numerical overflows.
+ *
+ * @param mu Real value ofr mean mu.
+ * @param phi Real value for phi.
+ *
+ * @return A random sample from the negative binomial distribution.
+ */
+int neg_binomial_2_safe_rng(real mu, real phi) {
+  if (mu < 1e-8) {
+    return(0);
+  } else if (phi > 1e4) {
+    return(poisson_rng(mu > 1e8 ? 1e8 : mu));
+  } else {
+    real gamma_rate = gamma_rng(phi, phi / mu);
+    return(poisson_rng(gamma_rate > 1e8 ? 1e8 : gamma_rate));
+  }
+}
+
 /**
  * Generate random samples of reported cases
  *
@@ -209,16 +232,7 @@ array[] int report_rng(vector reports, real rep_phi, int model_type) {
   }
 
   for (s in 1:t) {
-    if (reports[s] < 1e-8) {
-      sampled_reports[s] = 0;
-    } else {
-      // defer to poisson if phi is large, to avoid overflow
-      if (dispersion > 1e4) {
-        sampled_reports[s] = poisson_rng(reports[s] > 1e8 ? 1e8 : reports[s]);
-      } else {
-        sampled_reports[s] = neg_binomial_2_rng(reports[s] > 1e8 ? 1e8 : reports[s], dispersion);
-      }
-    }
+    sampled_reports[s] = neg_binomial_2_safe_rng(reports[s], dispersion);
   }
   return(sampled_reports);
 }


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #963 by implementing a safe version of the negative binomial 2 rng. Existing code for avoiding numerical issues with this has been moved into the function.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [x] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

