### PR TITLE
Install `cyclocomp` in `lintr` workflow

### DIFF
--- a/.github/workflows/lint-only-changed-files.yaml
+++ b/.github/workflows/lint-only-changed-files.yaml
@@ -30,6 +30,7 @@ jobs:
             any::lintr
             any::purrr
             progressr
+            any::cyclocomp
 
       - name: Add lintr options
         run: |


### PR DESCRIPTION
This PR fixes an issue in the CI for #998 that requires installing `cyclocomp` in the lint-only-changed-files workflow. 

I see it's a result of this breaking change in lintr https://github.com/r-lib/lintr/issues/2554.
