### PR TITLE
fix shifted reports prior

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # EpiNow2 (development version)
 
+## Bug fixes
+
+- a bug was fixed where shifted cases for the deconvolution model did not reflect accumulation settings. By @sbfnk in # and reviewed by @.
+
 # EpiNow2 1.7.1
 
 This is a patch release in response to an upstream issue in `rstan`, as flagged in CRAN checks.

--- a/R/create.R
+++ b/R/create.R
@@ -55,6 +55,9 @@
 create_shifted_cases <- function(data, shift,
                                  smoothing_window, horizon) {
   shifted_reported_cases <- data.table::copy(data)[
+    is.na(confirm) & accumulate,
+    confirm := 0
+  ][
     ,
     confirm := data.table::shift(confirm,
       n = shift,


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR addresses part of #990 (item (1) in https://github.com/epiforecasts/EpiNow2/issues/990#issuecomment-2653766029).

It doesn't address the broader issue that the default alpha prior is not suitable for the deconvolution model.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

