### PR TITLE
Fix partial match of `h` to `horizon`

### DIFF
--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -668,7 +668,7 @@ forecast_secondary <- function(estimate,
   )
   stan_data$n <- nrow(stan_data$primary)
   stan_data$t <- ncol(stan_data$primary)
-  stan_data$h <- nrow(primary[sample == min(sample)])
+  stan_data$horizon <- nrow(primary[sample == min(sample)])
 
   # extract samples for posterior of estimates
   posterior_samples <- sample(stan_data$n, stan_data$n, replace = TRUE)
@@ -702,7 +702,7 @@ forecast_secondary <- function(estimate,
   samples <- samples[
     ,
     date := rep(
-      tail(dates, ifelse(all_dates, stan_data$t, stan_data$h)),
+      tail(dates, ifelse(all_dates, stan_data$t, stan_data$horizon)),
       stan_data$n
     )
   ]

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -380,7 +380,7 @@ forecast_infections <- function(estimates,
 
   # redefine time if Rt != data$t
   est_time <- estimates$args$t
-  horizon <- estimates$args$h
+  horizon <- estimates$args$horizon
   obs_time <- est_time - shift
 
   if (obs_time != dim(draws$R)[2]) {

--- a/R/simulate_secondary.R
+++ b/R/simulate_secondary.R
@@ -60,7 +60,7 @@ simulate_secondary <- function(primary,
   stan_data <- list(
     n = 1,
     t = nrow(primary),
-    h = nrow(primary),
+    horizon = nrow(primary),
     all_dates = 0,
     obs = array(integer(0)),
     primary = array(primary$primary, dim = c(1, nrow(primary))),

--- a/inst/stan/simulate_secondary.stan
+++ b/inst/stan/simulate_secondary.stan
@@ -11,10 +11,10 @@ data {
   // dimensions
   int n; // number of samples
   int t; // time
-  int h; // forecast horizon
+  int horizon; // forecast horizon
   int all_dates; // should all dates have simulations returned
   // secondary model specific data
-  array[t - h] int<lower = 0> obs;         // observed secondary data
+  array[t - horizon] int<lower = 0> obs;         // observed secondary data
   matrix[n, t] primary;              // observed primary data
 #include data/secondary.stan
 #include data/simulation_delays.stan
@@ -32,7 +32,7 @@ transformed data {
 }
 
 generated quantities {
-  array[n, all_dates ? t : h] int sim_secondary;
+  array[n, all_dates ? t : horizon] int sim_secondary;
   {
     vector[n] dispersion = get_param(
       dispersion_id, params_fixed_lookup, params_variable_lookup,
@@ -68,7 +68,7 @@ generated quantities {
       // calculate secondary reports from primary
       secondary = calculate_secondary(
         scaled, convolved, obs, cumulative, historic, primary_hist_additive,
-        current, primary_current_additive, t - h + 1
+        current, primary_current_additive, t - horizon + 1
       );
 
       // weekly reporting effect
@@ -91,7 +91,7 @@ generated quantities {
 
       // simulate secondary reports
       sim_secondary[i] = report_rng(
-        tail(secondary, all_dates ? t : h), dispersion[i], model_type
+        tail(secondary, all_dates ? t : horizon), dispersion[i], model_type
       );
     }
   }


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This is not based on an issue but is a follow up to #1007 by replacing partial matches of `$h` with `$horizon`. 

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->


