### PR TITLE
Initial draft of design doc for fitting to multiple data streams

### DIFF
--- a/inst/dev/design_obs.md
+++ b/inst/dev/design_obs.md
@@ -37,17 +37,15 @@ The proposed solution is that the current `data`, `delays`, `truncation` and `fu
 ```r
 estimate_infections(
   obs = c(
-    obs_model(
+    "Confirmed cases" = obs_model(
       data = reported_cases,
-      type = "Confirmed cases",
       delays = incubation_period + reporting_delay,
       truncation = trunc_opts(Lognormal(1, 2)),
       family = "poisson",
       accumulation = 7
     ),
-    obs_model(
+    "Hospital admissions" = obs_model(
       data = admissions,
-      type = "Hospital admissions",
       delays = incubation_period + admission_delay,
       truncation = trunc_opts(Gamma(1, 1)),
       family = "negbin",
@@ -64,24 +62,24 @@ This covers the case where only confirmed cases are ever admitted to hospital.
 
 ```r
 estimate_infections(
-  obs = c(
-    obs_model(
+  ## "Confirmed cases" is the default name
+  obs = obs_model(
       data = reported_cases,
-      type = "Confirmed cases",
       delays = incubation_period + reporting_delay,
       truncation = trunc_opts(Lognormal(1, 2)),
       family = "poisson",
       accumulation = 7,
-      obs = obs_model(
-        data = admissions,
-        type = "Hospital admissions",
-        delays = admission_delay,
-        truncation = trunc_opts(Gamma(1, 1)),
-        family = "negbin",
-        weight = 0.5
+      obs = c(
+        "Hospital admissions" = obs_model(
+          data = admissions,
+          delays = admission_delay,
+          truncation = trunc_opts(Gamma(1, 1)),
+          family = "negbin",
+          weight = 0.5
+        )
       )
     ),
   ),
   generation_time = generation_time_opts(generation_time)
 )
-`
+```

--- a/inst/dev/design_obs.md
+++ b/inst/dev/design_obs.md
@@ -1,0 +1,55 @@
+# Combining multiple observation models
+
+The overall premise is that there is a single latent process (modelled as GP or with the renewal equation) that informs multiple observation processes. Each of these can have:
+
+- a delay or set of delays
+- truncation
+- scaling
+- accumulation
+- week(end) effects
+- different weights
+- overdispersion
+
+The delays need to be identified in case they are common across different observations, e.g.
+
+- incubation period + reporting delay for symptomatic cases
+- incubation period + hospital admission + another reporting delay for hospitalisations
+
+We're assuming that delays can be equal but the observations are independent (not e.g. hospitalisation conditional on case report)
+
+This means that the current options specified in `delay_opts()`, `trunc_opts()`, `obs_opts()`, the `accumulation` argument in `forecast_opts()` are all specific to the particular observation type.
+
+## Implementation
+
+### Stan
+
+Observations are converted from an array to a ragged array.
+The main required changes here will be lookups so that observations are correctly associated with different observation models.
+Some variables e.g. for day of the week effects will have to become 2D arrays.
+
+### R
+
+The observation options mentioned above will have to be combined in a single interface.
+The proposed solution is that the current `data`, `delays`, `truncation` and `future_accumulation` become folded into a new `obs_model()` (based on `obs_opts()` and these can be passed as `...`, e.g.
+
+```r
+estimate_infections(
+  cases = obs_model(
+    data = reported_cases,
+    delays = incubation_period + reporting_delay,
+    truncation = trunc_opts(Lognormal(1, 2)),
+    family = "poisson",
+    accumulation = 7
+  ),
+  hospitalisations = obs_model(
+    data = admissions,
+    delays = incubation_period + admission_delay,
+    truncation = trunc_opts(Gamma(1, 1)),
+    family = "negbin",
+    weight = 0.5
+  )
+  generation_time = generation_time_opts(generation_time)
+)
+```
+
+The main work will have to be on the interface, e.g. redefining seeding times., accessing predictions for the different observation types, merging dates, etc.

--- a/inst/dev/design_obs.md
+++ b/inst/dev/design_obs.md
@@ -17,7 +17,7 @@ The delays need to be identified in case they are common across different observ
 
 We're assuming that delays can be equal but the observations are independent (not e.g. hospitalisation conditional on case report)
 
-This means that the current options specified in `delay_opts()`, `trunc_opts()`, `obs_opts()`, the `accumulation` argument in `forecast_opts()` are all specific to the particular observation type.
+This means that the current options specified in `delay_opts()`, `trunc_opts()`, `obs_opts()`, the `accumulation` argument in `forecast_opts()` are all specific to the particular observation type, except delays that can be shared.
 
 ## Implementation
 


### PR DESCRIPTION
# Combining multiple observation models

The overall premise is that there is a single latent process (modelled as GP or with the renewal equation) that informs multiple observation processes. Each of these can have:

- a delay or set of delays
- truncation
- scaling
- accumulation
- week(end) effects
- different weights
- overdispersion

The delays need to be identified in case they are common across different observations, e.g.

- incubation period + reporting delay for symptomatic cases
- incubation period + hospital admission + another reporting delay for hospitalisations

We're assuming that delays can be equal but the observations are independent (not e.g. hospitalisation conditional on case report)

This means that the current options specified in `delay_opts()`, `trunc_opts()`, `obs_opts()`, the `accumulation` argument in `forecast_opts()` are all specific to the particular observation type.

## Implementation

### Stan

Observations are converted from an array to a ragged array.
The main required changes here will be lookups so that observations are correctly associated with different observation models.
Some variables e.g. for day of the week effects will have to become 2D arrays.

### R

The observation options mentioned above will have to be combined in a single interface.
The proposed solution is that the current `data`, `delays`, `truncation` and `future_accumulation` become folded into a new `obs_model()` (based on `obs_opts()` and these can be passed as `obs`.

#### Independent observations

```r
estimate_infections(
  obs = c(
    "Confirmed cases" = obs_model(
      data = reported_cases,
      delays = incubation_period + reporting_delay,
      truncation = trunc_opts(Lognormal(1, 2)),
      family = "poisson",
      accumulation = 7
    ),
    "Hospital admissions" = obs_model(
      data = admissions,
      delays = incubation_period + admission_delay,
      truncation = trunc_opts(Gamma(1, 1)),
      family = "negbin",
      weight = 0.5
    )
  ),
  generation_time = generation_time_opts(generation_time)
)
```

#### Dependent observations

This covers the case where only confirmed cases are ever admitted to hospital.

```r
estimate_infections(
  ## "Confirmed cases" is the default name
  obs = obs_model(
      data = reported_cases,
      delays = incubation_period + reporting_delay,
      truncation = trunc_opts(Lognormal(1, 2)),
      family = "poisson",
      accumulation = 7,
      obs = c(
        "Hospital admissions" = obs_model(
          data = admissions,
          delays = admission_delay,
          truncation = trunc_opts(Gamma(1, 1)),
          family = "negbin",
          weight = 0.5
        )
      )
    ),
  ),
  generation_time = generation_time_opts(generation_time)
)
```