### PR TITLE
deprecation tidy up

### DIFF
--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -223,9 +223,6 @@ estimate_infections <- function(data,
   # Add breakpoints column
   reported_cases <- add_breakpoints(reported_cases)
 
-  # Record earliest date with data
-  start_date <- min(reported_cases$date, na.rm = TRUE)
-
   # Determine seeding time
   seeding_time <- get_seeding_time(delays, generation_time, rt)
 

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -164,7 +164,7 @@ estimate_infections <- function(data,
       `weight_prior` argument."
     )
   }
-   if (!missing(horizon)) {
+  if (!missing(horizon)) {
     lifecycle::deprecate_stop(
       "1.7.0",
       "estimate_infections(horizon)",

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -274,8 +274,6 @@ estimate_infections <- function(data,
     posterior_samples = out,
     horizon = stan_data$horizon,
     shift = stan_data$seeding_time,
-    burn_in = 0,
-    start_date = start_date,
     CrIs = CrIs
   )
 

--- a/R/simulate_infections.R
+++ b/R/simulate_infections.R
@@ -501,8 +501,6 @@ forecast_infections <- function(estimates,
     posterior_samples = regional_out,
     horizon = estimates$args$horizon,
     shift = shift,
-    burn_in = 0,
-    start_date = min(estimates$observations$date),
     CrIs = extract_CrIs(estimates$summarised) / 100
   )
   format_out$samples <- format_out$samples[, sample := seq_len(.N),

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -420,7 +420,6 @@ lapply_func <- function(..., backend = "rstan", future.opts = list()) {
 ##' @param with What to pad with
 ##' @return A data.table of reported cases.
 ##' @importFrom data.table data.table rbindlist
-##' @inheritParams create_stan_data
 ##' @keywords internal
 pad_reported_cases <- function(reported_cases, n, with = NA_real_) {
   if (n > 0) {

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -76,11 +76,9 @@ settings if desired.}
 
 \item{CrIs}{Numeric vector of credible intervals to calculate.}
 
-\item{weigh_delay_priors}{Logical. If TRUE (default), all delay distribution
-priors will be weighted by the number of observation data points, in doing so
-approximately placing an independent prior at each time step and usually
-preventing the posteriors from shifting. If FALSE, no weight will be applied,
-i.e. delay distributions will be treated as a single parameters.}
+\item{weigh_delay_priors}{Deprecated; this is now specified at the
+distribution level in \code{generation_time_opts()}, \code{delay_opts()} and
+\code{trunc_opts()} using the \code{weight_prior} argument.}
 
 \item{id}{A character string used to assign logging information on error.
 Used by \code{\link[=regional_epinow]{regional_epinow()}} to assign errors to regions. Alter the default to

--- a/man/format_fit.Rd
+++ b/man/format_fit.Rd
@@ -14,9 +14,9 @@ format_fit(posterior_samples, horizon, shift, burn_in, start_date, CrIs)
 
 \item{shift}{Numeric, the shift to apply to estimates.}
 
-\item{burn_in}{Numeric, number of days to discard estimates for.}
+\item{burn_in}{Deprecated; this functionality is no longer available.}
 
-\item{start_date}{Date, earliest date with data.}
+\item{start_date}{Deprecated; this functionality is no longer available.}
 
 \item{CrIs}{Numeric vector of credible intervals to calculate.}
 }


### PR DESCRIPTION
## Description

Not linked to an Issue, but a tidy of two deprecations that must have fallen through the cracks:
- hard deprecate `weigh_delay_priors` (no longer being used so needs to error)
- `burn_in` in `format_fit()` (deprecated as of version 1.3.0)

Also tidies a stray `inheritParams`.
<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [ ] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

