### PR TITLE
Update param_id to use common prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Package changes
 
 - The package now has a hex logo.
-- Parameter IDs are now prefixed with `param_id_parameter_name` to make them easier to discover.
+- Parameter IDs are now prefixed with `param_id_parameter_name` to make them easier to discover. If you were previously extracting parameter posteriors with the pattern `[parameter_name]_id`, you now have to do `param_id_[parameter_name]`, for example, `frac_obs_id` is now `param_id_frac_obs`.
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 ## Package changes
 
 - The package now has a hex logo.
+- Parameter IDs are now prefixed with `param_id_parameter_name` to make them easier to discover.
 
 ## Bug fixes
 

--- a/R/create.R
+++ b/R/create.R
@@ -825,7 +825,7 @@ create_stan_params <- function(..., lower_bounds = NULL) {
   )
   ids <- seq_along(params)
   if (length(ids) > 0) {
-    names(ids) <- paste(names(params), "id", sep = "_")
+    names(ids) <- paste("param_id", names(params), sep = "_")
   }
   ret <- c(ret, as.list(ids), as.list(null_ids))
   return(ret)

--- a/R/create.R
+++ b/R/create.R
@@ -756,7 +756,9 @@ create_stan_params <- function(..., lower_bounds = NULL) {
   null_params <- vapply(params, is.null, logical(1))
   null_ids <- rep(0, sum(null_params))
   if (length(null_ids) > 0) {
-    names(null_ids) <- paste(names(null_params)[null_params], "id", sep = "_")
+    names(null_ids) <- paste(
+      "param_id", names(null_params)[null_params], sep = "_"
+    )
     params <- params[!null_params]
   }
 

--- a/inst/dev/stan-to-R.R
+++ b/inst/dev/stan-to-R.R
@@ -101,11 +101,11 @@ simulate <- function(data,
   )
   if (!fixed) {
     alpha <- get_param(
-      alpha_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_alpha, params_fixed_lookup, params_variable_lookup, params_value,
       params
     )
     rescaled_rho <- 2 * get_param(
-      rho_id, params_fixed_lookup, params_variable_lookup,
+      param_id_rho, params_fixed_lookup, params_variable_lookup,
       params_value, params
     ) / noise_terms
     noise <- update_gp(
@@ -122,13 +122,13 @@ simulate <- function(data,
       1, 1, 0
     )
     R0 <- get_param(
-      R0_id, params_fixed_lookup, params_variable_lookup, params_value, params
+      param_id_R0, params_fixed_lookup, params_variable_lookup, params_value, params
     )
     R <- update_Rt(
       ot_h, R0, noise, breakpoints, bp_effects, stationary
     )
     frac_obs <- get_param(
-      frac_obs_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_frac_obs, params_fixed_lookup, params_variable_lookup, params_value,
       params
     )
     pop <- get_param(
@@ -156,7 +156,7 @@ simulate <- function(data,
   }
   if (obs_scale) {
     frac_obs <- get_param(
-      frac_obs_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_frac_obs, params_fixed_lookup, params_variable_lookup, params_value,
       params
     )
     reports <- scale_obs(reports, frac_obs)
@@ -191,7 +191,7 @@ simulate <- function(data,
   )
   if (likelihood) {
     dispersion <- get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup, params_value,
       params
     )
     report_lp(
@@ -200,7 +200,7 @@ simulate <- function(data,
   }
   if (!fixed) {
     rescaled_rho <- get_param(
-      rho_id, params_fixed_lookup, params_variable_lookup,
+      param_id_rho, params_fixed_lookup, params_variable_lookup,
       params_value, params
     )
     x <- seq(1, noise_terms)

--- a/inst/stan/data/estimate_infections_params.stan
+++ b/inst/stan/data/estimate_infections_params.stan
@@ -1,5 +1,5 @@
-int<lower = 0> alpha_id; // parameter id of alpha (GP magnitude)
-int<lower = 0> rho_id; // parameter id of rho (GP lengthscale)
-int<lower = 0> R0_id; // parameter id of R0
-int<lower = 0> frac_obs_id; // parameter id of frac_obs
-int<lower = 0> dispersion_id; // parameter id of dispersion
+int<lower = 0> param_id_alpha; // parameter id of alpha (GP magnitude)
+int<lower = 0> param_id_rho; // parameter id of rho (GP lengthscale)
+int<lower = 0> param_id_R0; // parameter id of R0
+int<lower = 0> param_id_frac_obs; // parameter id of frac_obs
+int<lower = 0> param_id_dispersion; // parameter id of dispersion

--- a/inst/stan/data/estimate_secondary_params.stan
+++ b/inst/stan/data/estimate_secondary_params.stan
@@ -1,2 +1,2 @@
-int<lower = 0> frac_obs_id; // parameter id of frac_obs
-int<lower = 0> dispersion_id; // parameter id of dispersion
+int<lower = 0> param_id_frac_obs; // parameter id of frac_obs
+int<lower = 0> param_id_dispersion; // parameter id of dispersion

--- a/inst/stan/estimate_infections.stan
+++ b/inst/stan/estimate_infections.stan
@@ -80,11 +80,11 @@ transformed parameters {
   profile("update gp") {
     if (!fixed) {
       real alpha = get_param(
-        alpha_id, params_fixed_lookup, params_variable_lookup, params_value,
+        param_id_alpha, params_fixed_lookup, params_variable_lookup, params_value,
         params
       );
       real rescaled_rho = 2 * get_param(
-        rho_id, params_fixed_lookup, params_variable_lookup,
+        param_id_rho, params_fixed_lookup, params_variable_lookup,
         params_value, params
       ) / noise_terms;
       noise = update_gp(
@@ -105,7 +105,7 @@ transformed parameters {
     }
     profile("R0") {
       real R0 = get_param(
-        R0_id, params_fixed_lookup, params_variable_lookup, params_value, params
+        param_id_R0, params_fixed_lookup, params_variable_lookup, params_value, params
       );
       R = update_Rt(
         ot_h, R0, noise, breakpoints, bp_effects, stationary
@@ -113,7 +113,7 @@ transformed parameters {
     }
     profile("infections") {
       real frac_obs = get_param(
-        frac_obs_id, params_fixed_lookup, params_variable_lookup, params_value,
+        param_id_frac_obs, params_fixed_lookup, params_variable_lookup, params_value,
         params
       );
       infections = generate_infections(
@@ -159,7 +159,7 @@ transformed parameters {
   if (obs_scale) {
     profile("scale") {
       real frac_obs = get_param(
-        frac_obs_id, params_fixed_lookup, params_variable_lookup, params_value,
+        param_id_frac_obs, params_fixed_lookup, params_variable_lookup, params_value,
         params
       );
       reports = scale_obs(reports, frac_obs);
@@ -229,7 +229,7 @@ model {
   if (likelihood) {
     profile("report lp") {
       real dispersion = get_param(
-        dispersion_id, params_fixed_lookup, params_variable_lookup, params_value,
+        param_id_dispersion, params_fixed_lookup, params_variable_lookup, params_value,
         params
       );
       report_lp(
@@ -247,12 +247,12 @@ generated quantities {
 
   profile("generated quantities") {
     real dispersion = get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup, params_value,
       params
     );
     if (!fixed) {
       real rescaled_rho = 2 * get_param(
-        rho_id, params_fixed_lookup, params_variable_lookup,
+        param_id_rho, params_fixed_lookup, params_variable_lookup,
         params_value, params
       ) / noise_terms;
       vector[noise_terms] x = linspaced_vector(noise_terms, 1, noise_terms);

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -48,7 +48,7 @@ transformed parameters {
     // scaling of primary reports by fraction observed
     if (obs_scale) {
       real frac_obs = get_param(
-        frac_obs_id, params_fixed_lookup, params_variable_lookup, params_value,
+        param_id_frac_obs, params_fixed_lookup, params_variable_lookup, params_value,
         params
       );
       scaled = scale_obs(primary, frac_obs);
@@ -114,7 +114,7 @@ model {
   // observed secondary reports from mean of secondary reports (update likelihood)
   if (likelihood) {
     real dispersion = get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup, params_value,
       params
     );
     report_lp(
@@ -129,7 +129,7 @@ generated quantities {
   vector[return_likelihood > 1 ? t - burn_in : 0] log_lik;
   {
     real dispersion = get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup, params_value,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup, params_value,
       params
     );
     // simulate secondary reports

--- a/inst/stan/simulate_infections.stan
+++ b/inst/stan/simulate_infections.stan
@@ -43,11 +43,11 @@ generated quantities {
   matrix[n, t - seeding_time - 1] r;
   {
     vector[n] dispersion = get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup,
       params_value, params
     );
     vector[n] frac_obs = get_param(
-      frac_obs_id, params_fixed_lookup, params_variable_lookup,
+      param_id_frac_obs, params_fixed_lookup, params_variable_lookup,
       params_value, params
     );
     for (i in 1:n) {

--- a/inst/stan/simulate_secondary.stan
+++ b/inst/stan/simulate_secondary.stan
@@ -35,11 +35,11 @@ generated quantities {
   array[n, all_dates ? t : horizon] int sim_secondary;
   {
     vector[n] dispersion = get_param(
-      dispersion_id, params_fixed_lookup, params_variable_lookup,
+      param_id_dispersion, params_fixed_lookup, params_variable_lookup,
       params_value, params
     );
     vector[n] frac_obs = get_param(
-      frac_obs_id, params_fixed_lookup, params_variable_lookup,
+      param_id_frac_obs, params_fixed_lookup, params_variable_lookup,
       params_value, params
     );
     for (i in 1:n) {

--- a/tests/testthat/test-create_stan_params.R
+++ b/tests/testthat/test-create_stan_params.R
@@ -6,7 +6,7 @@ test_that("create_stan_params can be used with a scaling", {
   expect_equal(params$prior_dist, array(2L))
   expect_equal(params$prior_dist_params, array(c(0.4, 0.01)))
   expect_equal(params$params_lower, array(0))
-  expect_equal(params$frac_obs_id, 1L)
+  expect_equal(params$param_id_frac_obs, 1L)
 })
 
 test_that("create_stan_params can be used with fixed scaling", {
@@ -27,7 +27,7 @@ test_that("create_stan_params can be used with a user set phi", {
   )
   expect_equal(params$prior_dist, array(2L))
   expect_equal(params$prior_dist_params, array(c(10, 0.1)))
-  expect_equal(params$dispersion_id, 1L)
+  expect_equal(params$param_id_dispersion, 1L)
 })
 
 test_that("create_stan_params can be used with fixed dispersion", {
@@ -43,7 +43,7 @@ test_that("create_stan_params can be used with NULL parameters", {
   params <- create_stan_params(
     test = NULL
   )
-  expect_equal(params$test_id, 0)
+  expect_equal(params$param_id_test, 0)
 })
 
 test_that("create_stan_params warns about uncertain parameters", {


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #1048. It uses a prefix to improve discoverability of the parameter ids.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

