### PR TITLE
issue 1073: use custom convolution function and drop trailing zeroes from PMF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 - A bug was fixed where `opts_list()` recursed lists which it shouldn't.
 - A bug was fixed where shifted cases for the deconvolution model did not reflect accumulation settings.
 - A bug was fixed where `estimate_infection()` threw an error if there were too many consecutive `NA` observations.
+- A bug was fixed where an error was thrown when convolving delay distributions with very small values.
 
 # EpiNow2 1.7.1
 

--- a/R/dist_spec.R
+++ b/R/dist_spec.R
@@ -447,6 +447,9 @@ discretise <- function(x, ...) {
 #' distribution cannot be discretised (e.g., because no finite maximum has been
 #' specified or parameters are uncertain). If `FALSE` then any distribution
 #' that cannot be discretised will be returned as is.
+#' @param remove_trailing_zeros Logical; If `TRUE` (default), trailing zeroes
+#'   in the resulting PMF will be removed. If `FALSE`, trailing zeroes will be
+#'   retained.
 #' @param ... ignored
 #' @importFrom cli cli_abort
 #' @return A `<dist_spec>` where all distributions with constant parameters are
@@ -467,7 +470,7 @@ discretise <- function(x, ...) {
 #'
 #' # The maxf the sum of two distributions
 #' discretise(dist1 + dist2, strict = FALSE)
-discretise.dist_spec <- function(x, strict = TRUE, ...) {
+discretise.dist_spec <- function(x, strict = TRUE, remove_trailing_zeros = TRUE, ...) {
   ## discretise
   if (!is_constrained(x) && strict) {
     cli_abort(
@@ -500,6 +503,9 @@ discretise.dist_spec <- function(x, strict = TRUE, ...) {
     )
     for (attribute in preserve_attributes) {
       attributes(y)[attribute] <- attributes(x)[attribute]
+    }
+    if (remove_trailing_zeros) {
+      y$pmf <- y$pmf[1:max(which(y$pmf != 0))]
     }
     return(y)
   } else if (strict) {

--- a/R/dist_spec.R
+++ b/R/dist_spec.R
@@ -470,7 +470,8 @@ discretise <- function(x, ...) {
 #'
 #' # The maxf the sum of two distributions
 #' discretise(dist1 + dist2, strict = FALSE)
-discretise.dist_spec <- function(x, strict = TRUE, remove_trailing_zeros = TRUE, ...) {
+discretise.dist_spec <- function(x, strict = TRUE, remove_trailing_zeros = TRUE,
+                                 ...) {
   ## discretise
   if (!is_constrained(x) && strict) {
     cli_abort(
@@ -505,7 +506,7 @@ discretise.dist_spec <- function(x, strict = TRUE, remove_trailing_zeros = TRUE,
       attributes(y)[attribute] <- attributes(x)[attribute]
     }
     if (remove_trailing_zeros) {
-      y$pmf <- y$pmf[1:max(which(y$pmf != 0))]
+      y$pmf <- y$pmf[seq_len(max(which(y$pmf != 0)))]
     }
     return(y)
   } else if (strict) {

--- a/R/dist_spec.R
+++ b/R/dist_spec.R
@@ -544,7 +544,6 @@ collapse <- function(x, ...) {
 #' @param ... ignored
 #' @return A `<dist_spec>` where consecutive nonparametric distributions
 #' have been convolved
-#' @importFrom stats convolve
 #' @importFrom cli cli_abort
 #' @method collapse dist_spec
 #' @export
@@ -586,9 +585,8 @@ collapse.multi_dist_spec <- function(x, ...) {
   for (id in collapseable) {
     ## collapse distributions
     for (next_id in next_ids[id]) {
-      x[[ids[id]]]$pmf <- convolve(
-        get_pmf(x[[ids[id]]]), rev(get_pmf(x[[next_id]])),
-        type = "open"
+      x[[ids[id]]]$pmf <- stable_convolve(
+        get_pmf(x[[ids[id]]]), rev(get_pmf(x[[next_id]]))
       )
     }
   }

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -443,6 +443,26 @@ pad_reported_cases <- function(reported_cases, n, with = NA_real_) {
   rbindlist(list(pad_dt, reported_cases))
 }
 
+#' Numerically stable convolution function for two pmf vectors
+#'
+#' Unlike [stats::convolve()], this function does not use the FFT algorithm,
+#' which can generate negative numbers when below machine precision.
+#'
+#' @param a Numeric vector, the first sequence.
+#' @param b Numeric vector, the second sequence.
+#' @return A numeric vector representing the convolution of `a` and `b`.
+stable_convolve <- function(a, b) {
+  n <- length(a)
+  m <- length(b)
+  result <- numeric(n + m - 1)
+  for (i in seq_along(a)) {
+    for (j in seq_along(b)) {
+      result[i + j - 1] <- result[i + j - 1] + a[i] * b[m - j + 1]
+    }
+  }
+  return(result)
+}
+
 #' @importFrom stats glm median na.omit pexp pgamma plnorm quasipoisson rexp
 #' @importFrom stats rlnorm rnorm rpois runif sd var rgamma pnorm
 globalVariables(

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -460,7 +460,7 @@ stable_convolve <- function(a, b) {
       result[i + j - 1] <- result[i + j - 1] + a[i] * b[m - j + 1]
     }
   }
-  return(result)
+  result
 }
 
 #' @importFrom stats glm median na.omit pexp pgamma plnorm quasipoisson rexp

--- a/man/discretise.Rd
+++ b/man/discretise.Rd
@@ -6,7 +6,7 @@
 \alias{discretize}
 \title{Discretise a <dist_spec>}
 \usage{
-\method{discretise}{dist_spec}(x, strict = TRUE, ...)
+\method{discretise}{dist_spec}(x, strict = TRUE, remove_trailing_zeros = TRUE, ...)
 
 discretize(x, ...)
 }
@@ -17,6 +17,10 @@ discretize(x, ...)
 distribution cannot be discretised (e.g., because no finite maximum has been
 specified or parameters are uncertain). If \code{FALSE} then any distribution
 that cannot be discretised will be returned as is.}
+
+\item{remove_trailing_zeros}{Logical; If \code{TRUE} (default), trailing zeroes
+in the resulting PMF will be removed. If \code{FALSE}, trailing zeroes will be
+retained.}
 
 \item{...}{ignored}
 }

--- a/tests/testthat/test-dist_spec.R
+++ b/tests/testthat/test-dist_spec.R
@@ -12,7 +12,7 @@ test_that("dist_spec returns correct output for fixed lognormal distribution", {
   )
 })
 
-test_that("discretise and collapse work with combined LogNormal distributions", {
+test_that("discretise and collapse work with LogNormal distributions with trailing zeroes", {
   dist1 <- LogNormal(mean = 1.77, sd = 1.08, max = 30)
   dist2 <- LogNormal(mean = 4.4, sd = 0.67, max = 30)
   combined <- dist1 + dist2

--- a/tests/testthat/test-dist_spec.R
+++ b/tests/testthat/test-dist_spec.R
@@ -15,10 +15,8 @@ test_that("dist_spec returns correct output for fixed lognormal distribution", {
 test_that("discretise and collapse work with LogNormal distributions with trailing zeroes", {
   dist1 <- LogNormal(mean = 1.77, sd = 1.08, max = 30)
   dist2 <- LogNormal(mean = 4.4, sd = 0.67, max = 30)
-  combined <- dist1 + dist2
-  expect_error_free({
-    result <- collapse(discretise(combined))
-  })
+  result <- collapse(discretise(dist1 + dist2))
+  expect_true(all(result$pmf >= 0))
 })
 
 test_that("dist_spec returns correct output for uncertain gamma distribution", {

--- a/tests/testthat/test-dist_spec.R
+++ b/tests/testthat/test-dist_spec.R
@@ -12,6 +12,15 @@ test_that("dist_spec returns correct output for fixed lognormal distribution", {
   )
 })
 
+test_that("discretise and collapse work with combined LogNormal distributions", {
+  dist1 <- LogNormal(mean = 1.77, sd = 1.08, max = 30)
+  dist2 <- LogNormal(mean = 4.4, sd = 0.67, max = 30)
+  combined <- dist1 + dist2
+  expect_error_free({
+    result <- collapse(discretise(combined))
+  })
+})
+
 test_that("dist_spec returns correct output for uncertain gamma distribution", {
   result <- discretise(
     Gamma(shape = Normal(3, 0.5), rate = Normal(2, 0.5), max = 19),


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #1073.

It uses a custom convolution instead of the FFT-based `stats::convolve()` -- presumably slower but this is not a concern here. This avoids the negative values.

It also adds a feature to drop trailing values from PMF when discretising and these are indistinguishable from zero. This is not critical but I can't see a reason to carry these around.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [X] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

