### PR TITLE
Fix buggy use of `exists()` to check for list elements

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,7 @@
 - A bug was fixed where `estimate_infection()` threw an error if there were too many consecutive `NA` observations.
 - A bug was fixed where an error was thrown when convolving delay distributions with very small values.
 - A bug was fixed where a cli warning was broken due to bad syntax.
+- A bug was fixed where the use of `exists()` in the codebase was causing errors.
 
 ## Documentation
 

--- a/R/fit.R
+++ b/R/fit.R
@@ -43,11 +43,11 @@ fit_model_with_nuts <- function(args, future = FALSE, max_execution_time = Inf,
     name = "EpiNow2.epinow.estimate_infections.fit"
   )
 
-  if (exists("stuck_chains", args)) {
+  if (is.null(args$stuck_chains)) {
+    stuck_chains <- 0
+  } else {
     stuck_chains <- args$stuck_chains
     args$stuck_chains <- NULL
-  } else {
-    stuck_chains <- 0
   }
 
   fit_chain <- function(chain, stan_args, max_time, catch = FALSE) {
@@ -180,11 +180,11 @@ fit_model_approximate <- function(args, future = FALSE, id = "stan") {
     name = "EpiNow2.epinow.estimate_infections.fit"
   )
 
-  if (exists("trials", args)) {
+  if (is.null(args$trials)) {
+    trials <- 1
+  } else {
     trials <- args$trials
     args$trials <- NULL
-  } else {
-    trials <- 1
   }
 
   fit_approximate <- function(stan_args) {

--- a/tests/testthat/test-estimate_infections.R
+++ b/tests/testthat/test-estimate_infections.R
@@ -155,6 +155,14 @@ test_that("estimate_infections works as expected with failing chains", {
       future = TRUE
     )
   ))
+  # test with stuck_chains = NULL
+   test_estimate_infections(reported_cases,
+    add_stan = list(
+      chains = 4,
+      stuck_chains = NULL,
+      future = TRUE
+    )
+  )
 })
 
 test_that("estimate_infections produces no forecasts when forecast = NULL", {


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #1096.

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

