### PR TITLE
fix: remove visible nolint from obs_opts() docs

### DIFF
--- a/R/opts.R
+++ b/R/opts.R
@@ -555,6 +555,7 @@ gp_opts <- function(basis_prop = 0.2,
   return(gp)
 }
 
+# nolint start
 #' Observation Model Options
 #'
 #' @description `r lifecycle::badge("stable")`
@@ -566,7 +567,7 @@ gp_opts <- function(basis_prop = 0.2,
 #'   parameter of the reporting process, used only if `familiy` is "negbin".
 #'   Internally parameterised such that this parameter is one over the square
 #'   root of the `phi` parameter for overdispersion of the
-#'   [negative binomial distribution](https://mc-stan.org/docs/functions-reference/unbounded_discrete_distributions.html#neg-binom-2-log). # nolint
+#'   [negative binomial distribution](https://mc-stan.org/docs/functions-reference/unbounded_discrete_distributions.html#neg-binom-2-log).
 #'   Defaults to a half-normal distribution with mean of 0 and
 #'   standard deviation of 0.25: `Normal(mean = 0, sd = 0.25)`. A lower limit of
 #'   zero will be enforced automatically.
@@ -602,6 +603,7 @@ gp_opts <- function(basis_prop = 0.2,
 #'
 #' # Scale reported data
 #' obs_opts(scale = Normal(mean = 0.2, sd = 0.02))
+# nolint end
 obs_opts <- function(family = c("negbin", "poisson"),
                      dispersion = Normal(mean = 0, sd = 0.25),
                      weight = 1,

--- a/man/obs_opts.Rd
+++ b/man/obs_opts.Rd
@@ -25,7 +25,7 @@ Negative binomial ("negbin"), the default, and Poisson.}
 parameter of the reporting process, used only if \code{familiy} is "negbin".
 Internally parameterised such that this parameter is one over the square
 root of the \code{phi} parameter for overdispersion of the
-\href{https://mc-stan.org/docs/functions-reference/unbounded_discrete_distributions.html#neg-binom-2-log}{negative binomial distribution}. # nolint
+\href{https://mc-stan.org/docs/functions-reference/unbounded_discrete_distributions.html#neg-binom-2-log}{negative binomial distribution}.
 Defaults to a half-normal distribution with mean of 0 and
 standard deviation of 0.25: \code{Normal(mean = 0, sd = 0.25)}. A lower limit of
 zero will be enforced automatically.}


### PR DESCRIPTION
<!--
  Thanks for opening this Pull Request! Below we have provided a suggested
  template for PRs to this repository and a checklist to complete before
  opening a PR.
 
  If this is your first Pull Request, please make sure you read the
  contributing guidelines linked below and at
  https://github.com/epiforecasts/EpiNow2/blob/main/.github/CONTRIBUTING.md
-->

## Description

This PR closes #1111 

<!-- Add any additional context for or description of the changes that you made in this pull request. -->

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- Thanks again for this PR - @EpiNow2 dev team -->

