### PR TITLE
Fix truncation PMF vector dimension mismatch in estimate_secondary.stan

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
 
 ## Bug fixes
 
+- A bug was fixed where the truncation PMF vector in `estimate_secondary.stan` was declared with incorrect dimension, causing a dimension mismatch with the `get_delay_rev_pmf()` function call.
 - A bug was fixed where the `CrIs` parameter in `epinow()` was not being passed through to internal functions, causing user-specified credible intervals to be ignored in saved files and output.
 - A bug was fixed where `forecast_infections` would fail with `samples = 1`.
 - A bug was fixed where `opts_list()` recursed lists which it shouldn't.

--- a/inst/stan/estimate_secondary.stan
+++ b/inst/stan/estimate_secondary.stan
@@ -81,7 +81,7 @@ transformed parameters {
 
   // truncate near time cases to observed reports
   if (trunc_id) {
-    vector[delay_type_max[trunc_id]] trunc_rev_cmf = get_delay_rev_pmf(
+    vector[delay_type_max[trunc_id] + 1] trunc_rev_cmf = get_delay_rev_pmf(
       trunc_id, delay_type_max[trunc_id] + 1, delay_types_p, delay_types_id,
       delay_types_groups, delay_max, delay_np_pmf,
       delay_np_pmf_groups, delay_params, delay_params_groups, delay_dist,


### PR DESCRIPTION
## Description

This PR closes #1181.

The `trunc_rev_cmf` vector in `estimate_secondary.stan` was declared with dimension `delay_type_max[trunc_id]` but the `get_delay_rev_pmf()` function call requests `delay_type_max[trunc_id] + 1` elements, causing a dimension mismatch.

This fix aligns `estimate_secondary.stan` with the four other Stan files that correctly include `+ 1` in both the declaration and function call:
- `estimate_infections.stan`
- `simulate_infections.stan`
- `simulate_secondary.stan`
- `estimate_truncation.stan`

## Initial submission checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **Bug Fixes**
  * Fixed incorrect dimension declaration in truncation delay calculations that was causing a mismatch when retrieving delay distributions. The delay probability mass function vector now correctly extends to accommodate all required bins in the truncation pathway.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->