### PR TITLE
Remove unnecessary explicit return statements

### DIFF
--- a/R/checks.R
+++ b/R/checks.R
@@ -48,7 +48,7 @@ check_reports_valid <- function(data,
     assert_numeric(data$confirm, lower = 0)
   }
   assert_logical(data$accumulate, null.ok = TRUE)
-  return(invisible(data))
+  invisible(data)
 }
 
 #' Validate probability distribution for passing to stan

--- a/R/create.R
+++ b/R/create.R
@@ -149,7 +149,7 @@ create_future_rt <- function(future = c("latest", "project", "estimate"),
     out$fixed <- TRUE
     out$from <- as.integer(future)
   }
-  return(out)
+  out
 }
 
 #' Create Time-varying Reproduction Number Data
@@ -275,7 +275,7 @@ create_rt_data <- function(rt = rt_opts(), breakpoints = NULL,
       "infections" = 0, "infectiousness" = 1
     )[[rt$growth_method]]
   )
-  return(rt_data)
+  rt_data
 }
 #' Create Back Calculation Data
 #'
@@ -371,7 +371,7 @@ create_gp_data <- function(gp = gp_opts(), data) {
   )
 
   gp_data <- c(data, gp_data)
-  return(gp_data)
+  gp_data
 }
 
 #' Create Observation Model Settings
@@ -416,7 +416,7 @@ create_obs_model <- function(obs = obs_opts(), dates) {
 
   opts$day_of_week <- add_day_of_week(dates, opts$week_effect)
 
-  return(opts)
+  opts
 }
 
 #' Create Stan Data Required for estimate_infections
@@ -674,7 +674,7 @@ create_stan_args <- function(stan = stan_opts(),
   )
   stan_args <- modifyList(stan_args, stan)
   stan_args$return_fit <- NULL
-  return(stan_args)
+  stan_args
 }
 
 ##' Create delay variables for stan
@@ -776,7 +776,7 @@ create_stan_delays <- function(..., time_points = 1L) {
   names(ret) <- paste("delay", names(ret), sep = "_")
   ret <- c(ret, ids)
 
-  return(ret)
+  ret
 }
 
 ##' Create parameters for stan

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -295,5 +295,5 @@ estimate_infections <- function(data,
 
   ## Join stan fit if required
   class(ret) <- c("epinowfit", "estimate_infections", class(ret))
-  return(ret)
+  ret
 }

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -281,7 +281,7 @@ estimate_secondary <- function(data,
   out$data <- stan_data
   out$fit <- fit
   class(out) <- c("estimate_secondary", class(out))
-  return(out)
+  out
 }
 
 #' Update estimate_secondary default priors
@@ -346,7 +346,7 @@ update_secondary_args <- function(data, priors, verbose = TRUE) {
       data$dispersion_sd <- signif(dispersion$sd, 3)
     }
   }
-  return(data)
+  data
 }
 
 #' Plot method for estimate_secondary


### PR DESCRIPTION
## Description

Remove explicit `return()` statements at the end of functions where R's implicit return behaviour is sufficient. This fixes lint warnings from `return_linter`.

## Initial submission checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code style improvements made with no impact on functionality or user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->