### PR TITLE
Fix forecast_infections test failures from reduced fixture size

### DIFF
--- a/tests/testthat/test-forecast-infections.R
+++ b/tests/testthat/test-forecast-infections.R
@@ -5,6 +5,14 @@ skip_on_cran()
 
 futile.logger::flog.threshold("FATAL")
 
+# Helper to build R vector that fits within fixture constraints
+make_adjusted_R <- function(estimate_infections, adjusted_values) {
+
+  n_R <- nrow(summary(estimate_infections, type = "parameters", param = "R"))
+  n_adjusted <- length(adjusted_values)
+  c(rep(NA_real_, n_R - n_adjusted), adjusted_values)
+}
+
 # Core test: basic functionality (always runs)
 test_that("forecast_infections works with default settings", {
   fixtures <- get_test_fixtures()
@@ -75,7 +83,8 @@ test_that("forecast_infections works with cmdstanr backend", {
 test_that("forecast_infections works with an adjusted Rt", {
   skip_integration()
   fixtures <- get_test_fixtures()
-  R <- c(rep(NA_real_, 30), rep(0.5, 20))
+  adjusted <- rep(0.5, 20)
+  R <- make_adjusted_R(fixtures$estimate_infections, adjusted)
   sims <- forecast_infections(fixtures$estimate_infections, R)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
   expect_equal(tail(sims$summarised[variable == "R"]$median, 9), rep(0.5, 9))
@@ -84,7 +93,8 @@ test_that("forecast_infections works with an adjusted Rt", {
 test_that("forecast_infections works with a short adjusted Rt", {
   skip_integration()
   fixtures <- get_test_fixtures()
-  R <- c(rep(NA_real_, 30), rep(0.5, 7))
+  adjusted <- rep(0.5, 7)
+  R <- make_adjusted_R(fixtures$estimate_infections, adjusted)
   sims <- forecast_infections(fixtures$estimate_infections, R)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
   expect_equal(tail(sims$summarised[variable == "R"]$median, 5), rep(0.5, 5))
@@ -93,30 +103,39 @@ test_that("forecast_infections works with a short adjusted Rt", {
 test_that("forecast_infections works with a long adjusted Rt", {
   skip_integration()
   fixtures <- get_test_fixtures()
-  R <- c(rep(NA_real_, 30), rep(1.2, 20), rep(0.8, 20))
+  adjusted <- c(rep(1.2, 20), rep(0.8, 20))
+  R <- make_adjusted_R(fixtures$estimate_infections, adjusted)
   sims <- forecast_infections(fixtures$estimate_infections, R)
   sims10 <- forecast_infections(fixtures$estimate_infections, R, samples = 10)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
-  expect_equal(tail(sims$summarised[variable == "R"]$median, 40), R[31:70])
+  expect_equal(
+    tail(sims$summarised[variable == "R"]$median, length(adjusted)), adjusted
+  )
 })
 
 test_that("forecast infections can be run with a limited number of samples", {
   skip_integration()
   fixtures <- get_test_fixtures()
-  R <- c(rep(NA_real_, 30), rep(1.2, 20), rep(0.8, 20))
+  adjusted <- c(rep(1.2, 20), rep(0.8, 20))
+  R <- make_adjusted_R(fixtures$estimate_infections, adjusted)
   sims <- forecast_infections(fixtures$estimate_infections, R, samples = 10)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
-  expect_equal(tail(sims$summarised[variable == "R"]$median, 40), R[31:70])
+  expect_equal(
+    tail(sims$summarised[variable == "R"]$median, length(adjusted)), adjusted
+  )
   expect_equal(max(sims$samples$sample), 10)
 })
 
 test_that("forecast infections can be run with one sample", {
   skip_integration()
   fixtures <- get_test_fixtures()
-  R <- c(rep(NA_real_, 30), rep(1.2, 20), rep(0.8, 20))
+  adjusted <- c(rep(1.2, 20), rep(0.8, 20))
+  R <- make_adjusted_R(fixtures$estimate_infections, adjusted)
   sims <- forecast_infections(fixtures$estimate_infections, R, samples = 1)
   expect_equal(names(sims), c("samples", "summarised", "observations"))
-  expect_equal(tail(sims$summarised[variable == "R"]$median, 40), R[31:70])
+  expect_equal(
+    tail(sims$summarised[variable == "R"]$median, length(adjusted)), adjusted
+  )
   expect_equal(max(sims$samples$sample), 1)
 })
 


### PR DESCRIPTION
## Description

This PR closes #1205.

PR #1183 ("Optimise test suite performance with tiered testing strategy") reduced test fixtures from 50 days of data to 30 days. However, the R vectors in `forecast_infections` tests weren't updated to match. The tests used 40 NAs in R vectors, but the 30-day fixtures only produce ~37 R values. This caused NAs in positions 38-40 to have no original R values to substitute, resulting in NAs being passed to Stan.

The fix updates R vectors in `forecast_infections` tests to use 30 NAs (within the ~37 available R values from the 30-day fixtures) and adjusts test expectations accordingly.

## Initial submission checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite for infection forecast functionality to ensure validation robustness and compatibility with internal adjustments.

**Note:** No user-facing changes or new features in this release. This update focuses on test maintenance and does not affect functionality for end-users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->