### PR TITLE
Fix phi parameter usage in report_log_lik function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@ The function interface remains unchanged.
 
 ## Bug fixes
 
+- A bug was fixed where the `report_log_lik` Stan function used the raw overdispersion parameter instead of the transformed phi value, producing incorrect pointwise log-likelihood values for model comparison (LOO, WAIC).
 - A bug was fixed where the truncation PMF vector in `estimate_secondary.stan` was declared with incorrect dimension, causing a dimension mismatch with the `get_delay_rev_pmf()` function call.
 - A bug was fixed where the `CrIs` parameter in `epinow()` was not being passed through to internal functions, causing user-specified credible intervals to be ignored in saved files and output.
 - A bug was fixed where `forecast_infections` would fail with `samples = 1`.

--- a/inst/stan/functions/observation_model.stan
+++ b/inst/stan/functions/observation_model.stan
@@ -200,7 +200,7 @@ vector report_log_lik(array[] int cases, vector reports,
     real phi = inv_square(reporting_overdispersion);
     for (i in 1:t) {
       log_lik[i] = neg_binomial_2_lpmf(
-        cases[i] | reports[i], reporting_overdispersion
+        cases[i] | reports[i], phi
       ) * weight;
     }
   }


### PR DESCRIPTION
## Summary

- Fixes the `report_log_lik` Stan function which computed `phi = inv_square(reporting_overdispersion)` but then incorrectly passed the raw `reporting_overdispersion` parameter to `neg_binomial_2_lpmf` instead of `phi`

This PR closes #1222.

## Test plan

- [ ] Verify the fix matches the correct pattern used in `report_lp`
- [ ] Run existing tests to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect pointwise log-likelihood calculations for Negative Binomial models that affected model comparison metrics (LOO and WAIC).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->