### PR TITLE
Fix delay parameter naming with mixed parametric/nonparametric delays

### DIFF
--- a/tests/testthat/test-delays.R
+++ b/tests/testthat/test-delays.R
@@ -139,15 +139,19 @@ test_that("create_stan_delays sets ID to 0 for missing delays", {
 })
 
 test_that("extract_delays works with delay_id_* naming", {
-  # Create mock samples with delay_params
+  # Create mock samples with delay_params (2 samples, 2 params)
   samples <- list(
     delay_params = matrix(c(1.5, 2.0, 1.8, 2.2), nrow = 2, ncol = 2)
   )
-  # Args contain the ID lookup information
+  # Args contain the ID lookup information using existing delay variables
+  # Scenario: one delay type (generation_time) with one parametric delay
   args <- list(
-    delay_id_generation_time = c(1, 1),  # ID = 1
-    delay_id_reporting = c(0, 0),         # ID = 0 (not used)
-    delay_types_groups = c(1, 3)          # Group 1: cols 1-2
+    delay_id_generation_time = 1,
+    delay_id_reporting = 0,
+    delay_types_groups = c(1, 2),    # type 1 has flat delay 1
+    delay_types_p = c(1),            # flat delay 1 is parametric
+    delay_types_id = c(1),           # flat delay 1 is parametric delay 1
+    delay_params_groups = c(1, 3)    # parametric delay 1 has params 1-2
   )
 
   result <- EpiNow2:::extract_delays(samples, args = args)

--- a/tests/testthat/test-estimate_secondary.R
+++ b/tests/testthat/test-estimate_secondary.R
@@ -128,6 +128,21 @@ test_that("estimate_secondary recovers scaling parameter from incidence data", {
   expect_equal(scaling_mean, 0.4, tolerance = 0.05)
 })
 
+test_that("delay parameters are correctly named with mixed parametric/nonparametric delays", {
+  # Regression test for #1236: when truncation is Fixed(0) (nonparametric),
+  # the reporting delay parameters should still be named reporting[1], reporting[2]
+  # not truncation[1] (which was the bug)
+  samples <- get_samples(default_inc)
+  delay_samples <- samples[variable == "delay_params"]
+
+  # Both parameters should be named as reporting delay params
+  param_names <- unique(delay_samples$parameter)
+  expect_true("reporting[1]" %in% param_names)
+  expect_true("reporting[2]" %in% param_names)
+  # Should NOT have truncation parameters (Fixed(0) has none)
+  expect_false(any(grepl("truncation", param_names)))
+})
+
 # Variant tests: Only run in full test mode (EPINOW2_SKIP_INTEGRATION=false) -
 
 test_that("estimate_secondary successfully returns estimates when passed NA values", {


### PR DESCRIPTION
## Description

This PR closes #1236.

### Problem
When mixing parametric delays (e.g., LogNormal) with nonparametric delays (e.g., Fixed(0)), the parameter naming was incorrect. For example, with a LogNormal reporting delay and Fixed(0) truncation:
- `delay_params[1]` → correctly named `reporting[1]` (meanlog)
- `delay_params[2]` → incorrectly named `truncation[1]` instead of `reporting[2]` (sdlog)

### Root cause
`delay_types_groups` indexed all delay types (including nonparametric), but `delay_params` only contained parameters from parametric delays. This mismatch caused `extract_delays()` to use incorrect indices for naming.

### Fix
Added `delay_params_types_groups` in `create_stan_delays()` which correctly maps delay IDs to parameter column indices, accounting for nonparametric delays having zero parameters.

Updated `extract_delays()` to use `delay_params_types_groups` instead of `delay_types_groups` for parameter naming.

### Testing
Added regression test that verifies:
- `reporting[1]` and `reporting[2]` are correctly assigned
- No `truncation[*]` parameters appear when truncation is Fixed(0)

## Initial submission checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [x] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.