### PR TITLE
Fix delay parameter naming with mixed parametric/nonparametric delays

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -52,6 +52,7 @@ The function interface remains unchanged.
 
 ## Bug fixes
 
+- A bug was fixed where delay parameter naming was incorrect when mixing parametric and nonparametric delays.
 - A bug was fixed where the `report_log_lik` Stan function used the raw overdispersion parameter instead of the transformed phi value, producing incorrect pointwise log-likelihood values for model comparison (LOO, WAIC).
 - A bug was fixed where the truncation PMF vector in `estimate_secondary.stan` was declared with incorrect dimension, causing a dimension mismatch with the `get_delay_rev_pmf()` function call.
 - A bug was fixed where the `CrIs` parameter in `epinow()` was not being passed through to internal functions, causing user-specified credible intervals to be ignored in saved files and output.

--- a/R/extract.R
+++ b/R/extract.R
@@ -127,24 +127,43 @@ extract_delays <- function(samples) {
   delay_names <- rep(NA_character_, n_cols)
 
   # Check all delay_id_* variables to build the mapping
+  # Use types_p, types_id, and params_groups to correctly handle
+  # nonparametric delays which have no parameters
   id_vars <- grep("^delay_id_", names(samples), value = TRUE)
-  if (length(id_vars) > 0 && "delay_types_groups" %in% names(samples)) {
-    delay_types_groups <- samples[["delay_types_groups"]]
+  required_vars <- c(
+    "delay_types_groups", "delay_types_p", "delay_types_id", "delay_params_groups"
+  )
+  if (length(id_vars) > 0 && all(required_vars %in% names(samples))) {
+    types_groups <- samples[["delay_types_groups"]]
+    types_p <- samples[["delay_types_p"]]
+    types_id <- samples[["delay_types_id"]]
+    params_groups <- samples[["delay_params_groups"]]
 
     for (id_var in id_vars) {
       delay_name <- sub("^delay_id_", "", id_var)
       id <- samples[[id_var]][1]  # Take first value (same across samples)
 
-      # Check if this delay exists (ID > 0)
-      if (!is.na(id) && id > 0 && id < length(delay_types_groups)) {
-        start_idx <- delay_types_groups[id]
-        end_idx <- delay_types_groups[id + 1] - 1
+      # Check if this delay type exists (ID > 0)
+      if (!is.na(id) && id > 0 && id < length(types_groups)) {
+        # Get flat delay indices for this type
+        flat_start <- types_groups[id]
+        flat_end <- types_groups[id + 1] - 1
 
-        # Mark columns for this delay
-        for (i in seq_along(start_idx:end_idx)) {
-          col_idx <- start_idx + i - 1
-          if (col_idx <= n_cols) {
-            delay_names[col_idx] <- paste0(delay_name, "[", i, "]")
+        # Find parameter columns for parametric delays in this type
+        param_idx <- 1
+        for (flat_i in flat_start:flat_end) {
+          if (types_p[flat_i] == 1) {
+            # This flat delay is parametric
+            p_idx <- types_id[flat_i]
+            col_start <- params_groups[p_idx]
+            col_end <- params_groups[p_idx + 1] - 1
+
+            for (col in col_start:col_end) {
+              if (col <= n_cols) {
+                delay_names[col] <- paste0(delay_name, "[", param_idx, "]")
+                param_idx <- param_idx + 1
+              }
+            }
           }
         }
       }


### PR DESCRIPTION
## Summary

- Fixes incorrect parameter naming when mixing parametric and nonparametric delays
- Uses existing `delay_types_p`, `delay_types_id`, and `delay_params_groups` to correctly map delay type IDs to parameter columns

This PR closes #1236.

## Test plan

- [x] Added unit test for mixed parametric/nonparametric case
- [x] Existing delay tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: sbfnk-bot <242615673+sbfnk-bot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect naming of delay parameters when mixing parametric and nonparametric delays
  * Improved parameter naming validation and handling

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->