### PR TITLE
Improve @return documentation for estimation functions

### DIFF
--- a/R/epinow.R
+++ b/R/epinow.R
@@ -22,10 +22,16 @@
 #' @param plot_args A list of optional arguments passed to
 #' [plot.estimate_infections()].
 #'
-#' @return A list of output from estimate_infections with additional elements
-#'   summarising results and reporting errors if they have occurred.
+#' @return An `<epinow>` object (inheriting from `<estimate_infections>`)
+#' containing:
+#'
+#' - `fit`: The stan fit object.
+#' - `args`: A list of arguments used for fitting (stan data).
+#' - `observations`: The input data (`<data.frame>`).
+#' - `timing`: The run time (if `output` includes "timing").
 #' @export
-#' @seealso [estimate_infections()] [forecast_infections()] [regional_epinow()]
+#' @seealso [get_samples()] [get_predictions()] [get_delays()]
+#' [estimate_infections()] [forecast_infections()] [regional_epinow()]
 #' @inheritParams calc_CrIs
 #' @inheritParams setup_target_folder
 #' @inheritParams estimate_infections

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -71,14 +71,14 @@
 #' threshold then the zero is replaced using `fill`.
 #'
 #' @export
-#' @return An `<estimate_infections>` object which is a list of outputs
-#' including: the stan object (`fit`), arguments used to fit the model
-#' (`args`), and the observed data (`observations`). Use `summary()` to access
-#' estimates, `get_samples()` to extract posterior samples, and
-#' `get_predictions()` to access predicted reported cases.
+#' @return An `<estimate_infections>` object containing:
 #'
-#' @seealso [epinow()] [regional_epinow()] [forecast_infections()]
-#' [estimate_truncation()]
+#' - `fit`: The stan fit object.
+#' - `args`: A list of arguments used for fitting (stan data).
+#' - `observations`: The input data (`<data.frame>`).
+#'
+#' @seealso [get_samples()] [get_predictions()] [get_delays()] [epinow()]
+#' [regional_epinow()] [forecast_infections()] [estimate_truncation()]
 #' @inheritParams create_stan_args
 #' @inheritParams create_stan_data
 #' @inheritParams create_rt_data

--- a/R/estimate_secondary.R
+++ b/R/estimate_secondary.R
@@ -56,11 +56,13 @@
 #' @param verbose Logical, should model fitting progress be returned. Defaults
 #' to [interactive()].
 #'
-#' @return An `<estimate_secondary>` object which is a list of outputs
-#' including: the stan object (`fit`), arguments used to fit the model
-#' (`args`), and the observed data (`observations`). Use `summary()` to access
-#' estimates, `get_samples()` to extract posterior samples, and
-#' `get_predictions()` to access predictions.
+#' @return An `<estimate_secondary>` object containing:
+#'
+#' - `fit`: The stan fit object.
+#' - `args`: A list of arguments used for fitting (stan data).
+#' - `observations`: The input data (`<data.frame>`).
+#'
+#' @seealso [get_samples()] [get_predictions()] [get_delays()]
 #' @export
 #' @inheritParams estimate_infections
 #' @inheritParams update_secondary_args

--- a/R/estimate_truncation.R
+++ b/R/estimate_truncation.R
@@ -150,17 +150,7 @@ merge_trunc_pred_obs <- function(observations, predictions) {
 #' - `args`: A list of arguments used for fitting (stan data).
 #' - `fit`: The stan fit object.
 #'
-#' Use [get_delays()] to extract the estimated truncation distribution as a
-#' `<dist_spec>`, which can be passed to the `truncation` argument of
-#' [epinow()], [regional_epinow()], and [estimate_infections()].
-#'
-#' Use [get_predictions()] to extract truncation-adjusted estimates that can
-#' be compared to the observed data.
-#'
-#' S3 methods available: [summary.estimate_truncation()],
-#' [plot.estimate_truncation()], [get_samples.estimate_truncation()],
-#' [get_delays()], [get_predictions.estimate_truncation()].
-#'
+#' @seealso [get_samples()] [get_predictions()] [get_delays()]
 #' @export
 #' @inheritParams calc_CrIs
 #' @inheritParams estimate_infections

--- a/man/epinow.Rd
+++ b/man/epinow.Rd
@@ -128,8 +128,14 @@ threshold then the zero is replaced using \code{fill}.}
 horizon}
 }
 \value{
-A list of output from estimate_infections with additional elements
-summarising results and reporting errors if they have occurred.
+An \verb{<epinow>} object (inheriting from \verb{<estimate_infections>})
+containing:
+\itemize{
+\item \code{fit}: The stan fit object.
+\item \code{args}: A list of arguments used for fitting (stan data).
+\item \code{observations}: The input data (\verb{<data.frame>}).
+\item \code{timing}: The run time (if \code{output} includes "timing").
+}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
@@ -187,5 +193,6 @@ options(old_opts)
 }
 }
 \seealso{
+\code{\link[=get_samples]{get_samples()}} \code{\link[=get_predictions]{get_predictions()}} \code{\link[=get_delays]{get_delays()}}
 \code{\link[=estimate_infections]{estimate_infections()}} \code{\link[=forecast_infections]{forecast_infections()}} \code{\link[=regional_epinow]{regional_epinow()}}
 }

--- a/man/estimate_infections.Rd
+++ b/man/estimate_infections.Rd
@@ -104,11 +104,12 @@ threshold then the zero is replaced using \code{fill}.}
 horizon}
 }
 \value{
-An \verb{<estimate_infections>} object which is a list of outputs
-including: the stan object (\code{fit}), arguments used to fit the model
-(\code{args}), and the observed data (\code{observations}). Use \code{summary()} to access
-estimates, \code{get_samples()} to extract posterior samples, and
-\code{get_predictions()} to access predicted reported cases.
+An \verb{<estimate_infections>} object containing:
+\itemize{
+\item \code{fit}: The stan fit object.
+\item \code{args}: A list of arguments used for fitting (stan data).
+\item \code{observations}: The input data (\verb{<data.frame>}).
+}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#maturing}{\figure{lifecycle-maturing.svg}{options: alt='[Maturing]'}}}{\strong{[Maturing]}}
@@ -168,6 +169,6 @@ options(old_opts)
 }
 }
 \seealso{
-\code{\link[=epinow]{epinow()}} \code{\link[=regional_epinow]{regional_epinow()}} \code{\link[=forecast_infections]{forecast_infections()}}
-\code{\link[=estimate_truncation]{estimate_truncation()}}
+\code{\link[=get_samples]{get_samples()}} \code{\link[=get_predictions]{get_predictions()}} \code{\link[=get_delays]{get_delays()}} \code{\link[=epinow]{epinow()}}
+\code{\link[=regional_epinow]{regional_epinow()}} \code{\link[=forecast_infections]{forecast_infections()}} \code{\link[=estimate_truncation]{estimate_truncation()}}
 }

--- a/man/estimate_secondary.Rd
+++ b/man/estimate_secondary.Rd
@@ -91,11 +91,12 @@ number of cases based on the 7-day average. If the average is above this
 threshold then the zero is replaced using \code{fill}.}
 }
 \value{
-An \verb{<estimate_secondary>} object which is a list of outputs
-including: the stan object (\code{fit}), arguments used to fit the model
-(\code{args}), and the observed data (\code{observations}). Use \code{summary()} to access
-estimates, \code{get_samples()} to extract posterior samples, and
-\code{get_predictions()} to access predictions.
+An \verb{<estimate_secondary>} object containing:
+\itemize{
+\item \code{fit}: The stan fit object.
+\item \code{args}: A list of arguments used for fitting (stan data).
+\item \code{observations}: The input data (\verb{<data.frame>}).
+}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
@@ -178,4 +179,7 @@ plot(prev_preds, new_obs = cases, from = "2020-06-01")
 
 options(old_opts)
 }
+}
+\seealso{
+\code{\link[=get_samples]{get_samples()}} \code{\link[=get_predictions]{get_predictions()}} \code{\link[=get_delays]{get_delays()}}
 }

--- a/man/estimate_truncation.Rd
+++ b/man/estimate_truncation.Rd
@@ -65,17 +65,6 @@ An \verb{<estimate_truncation>} object containing:
 \item \code{args}: A list of arguments used for fitting (stan data).
 \item \code{fit}: The stan fit object.
 }
-
-Use \code{\link[=get_delays]{get_delays()}} to extract the estimated truncation distribution as a
-\verb{<dist_spec>}, which can be passed to the \code{truncation} argument of
-\code{\link[=epinow]{epinow()}}, \code{\link[=regional_epinow]{regional_epinow()}}, and \code{\link[=estimate_infections]{estimate_infections()}}.
-
-Use \code{\link[=get_predictions]{get_predictions()}} to extract truncation-adjusted estimates that can
-be compared to the observed data.
-
-S3 methods available: \code{\link[=summary.estimate_truncation]{summary.estimate_truncation()}},
-\code{\link[=plot.estimate_truncation]{plot.estimate_truncation()}}, \code{\link[=get_samples.estimate_truncation]{get_samples.estimate_truncation()}},
-\code{\link[=get_delays]{get_delays()}}, \code{\link[=get_predictions.estimate_truncation]{get_predictions.estimate_truncation()}}.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
@@ -146,4 +135,7 @@ out <- epinow(
 plot(out)
 options(old_opts)
 }
+}
+\seealso{
+\code{\link[=get_samples]{get_samples()}} \code{\link[=get_predictions]{get_predictions()}} \code{\link[=get_delays]{get_delays()}}
 }


### PR DESCRIPTION
## Description

This PR closes #1204.

Improves the `@return` documentation for the main estimation functions (`estimate_infections()`, `estimate_secondary()`, `estimate_truncation()`, and `epinow()`) to clearly document **stored components** available via `$` access: `fit`, `args`, `observations`.

Adds `@seealso` entries for accessor methods (`get_samples()`, `get_predictions()`, `get_delays()`) so users can discover them.

This follows R's idiomatic S3 pattern (as used by `lm()`, `lme4`, `brms`) where `$` access is used for stored components and methods are documented separately.

## Initial submission checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [X] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [ ] I have added a news item linked to this PR.

Note: This is a documentation-only change, so no tests or NEWS item are required.