### PR TITLE
Move future parameter from rt_opts() to forecast_opts()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,7 @@ The function interface remains unchanged.
 
 ## Package changes
 
+- The `future` argument has been moved from `rt_opts()` to `forecast_opts()`. Using `rt_opts(future = ...)` still works but will issue a deprecation warning.
 - Fixed integration tests for `estimate_truncation` and `estimate_secondary` parameter recovery, and updated `example_truncated` data generation to use the Stan `discretised_pmf` function directly.
 - Updated `setup_future()` to use `parallelly::availableCores()` instead of the re-exported `future::availableCores()`, and removed the deprecated `earlySignal` argument from `future::plan()` calls.
 - The test suite has been reorganised into core tests (fast, always run) and integration tests (slow, run weekly), improving local development speed by 77% (from 9 minutes to 2 minutes) whilst maintaining test coverage.

--- a/R/estimate_infections.R
+++ b/R/estimate_infections.R
@@ -212,6 +212,11 @@ estimate_infections <- function(data,
     rt <- NULL
   }
 
+  # Use future setting from forecast_opts (rt_opts$future is deprecated)
+  if (!is.null(rt) && !is.null(forecast$future)) {
+    rt$future <- forecast$future
+  }
+
   # Check verbose settings and set logger to match
   if (verbose) {
     futile.logger::flog.threshold(futile.logger::DEBUG,

--- a/R/opts.R
+++ b/R/opts.R
@@ -371,6 +371,14 @@ rt_opts <- function(prior = LogNormal(mean = 1, sd = 1),
 
   assert_number(pop_floor, lower = 0, finite = TRUE)
 
+  if (!missing(future)) {
+    lifecycle::deprecate_warn(
+      "1.8.0",
+      "rt_opts(future)",
+      "forecast_opts(future)"
+    )
+  }
+
   if (opts$use_rt) {
     opts$prior <- prior
   } else if (!missing(prior)) {
@@ -1065,9 +1073,7 @@ stan_opts <- function(object = NULL,
 
 #' Forecast options
 #' @description `r lifecycle::badge("stable")`
-#' Defines a list specifying the arguments passed to underlying stan
-#' backend functions via [stan_sampling_opts()] and [stan_vb_opts()]. Custom
-#' settings can be supplied which override the defaults.
+#' Defines forecast settings for [estimate_infections()] and related functions.
 #'
 #' @param horizon Numeric, defaults to 7. Number of days into the future to
 #' forecast.
@@ -1075,14 +1081,21 @@ stan_opts <- function(object = NULL,
 #'   any. If not given and observations are accumulated at constant frequency in
 #'   the data used for fitting then the same accumulation will be used in
 #'   forecasts unless set explicitly here.
-#' @return A `<forecast_opts>` object of forecast setting.
+#' @param future Character string, defaults to "latest". How to handle Rt
+#'   during the forecast period. Options are:
+#'   - "latest": Use the latest estimated Rt value
+#'   - "project": Continue the Gaussian process into the future
+#' @return A `<forecast_opts>` object of forecast settings.
 #' @seealso [fill_missing()]
 #' @export
 #' @examples
 #' forecast_opts(horizon = 28, accumulate = 7)
-forecast_opts <- function(horizon = 7, accumulate) {
+#' forecast_opts(horizon = 14, future = "project")
+forecast_opts <- function(horizon = 7, accumulate, future = "latest") {
+  future <- match.arg(future, c("latest", "project"))
   opts <- list(
-    horizon = horizon
+    horizon = horizon,
+    future = future
   )
   if (!missing(accumulate)) {
     opts$accumulate <- accumulate

--- a/man/forecast_opts.Rd
+++ b/man/forecast_opts.Rd
@@ -4,7 +4,7 @@
 \alias{forecast_opts}
 \title{Forecast options}
 \usage{
-forecast_opts(horizon = 7, accumulate)
+forecast_opts(horizon = 7, accumulate, future = "latest")
 }
 \arguments{
 \item{horizon}{Numeric, defaults to 7. Number of days into the future to
@@ -14,18 +14,24 @@ forecast.}
 any. If not given and observations are accumulated at constant frequency in
 the data used for fitting then the same accumulation will be used in
 forecasts unless set explicitly here.}
+
+\item{future}{Character string, defaults to "latest". How to handle Rt
+during the forecast period. Options are:
+\itemize{
+\item "latest": Use the latest estimated Rt value
+\item "project": Continue the Gaussian process into the future
+}}
 }
 \value{
-A \verb{<forecast_opts>} object of forecast setting.
+A \verb{<forecast_opts>} object of forecast settings.
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#stable}{\figure{lifecycle-stable.svg}{options: alt='[Stable]'}}}{\strong{[Stable]}}
-Defines a list specifying the arguments passed to underlying stan
-backend functions via \code{\link[=stan_sampling_opts]{stan_sampling_opts()}} and \code{\link[=stan_vb_opts]{stan_vb_opts()}}. Custom
-settings can be supplied which override the defaults.
+Defines forecast settings for \code{\link[=estimate_infections]{estimate_infections()}} and related functions.
 }
 \examples{
 forecast_opts(horizon = 28, accumulate = 7)
+forecast_opts(horizon = 14, future = "project")
 }
 \seealso{
 \code{\link[=fill_missing]{fill_missing()}}


### PR DESCRIPTION
## Summary

Moves the `future` parameter from `rt_opts()` to `forecast_opts()` where it logically belongs, since it controls forecasting behaviour rather than Rt estimation.

- Added `future` parameter to `forecast_opts()` with options "latest" (default) and "project"
- Added deprecation warning when using `rt_opts(future = ...)`
- `estimate_infections()` now uses `forecast$future` internally

Closes #918 

## Checklist

- [x] My PR is based on a package issue and I have explicitly linked it.
- [x] I have tested my changes locally (using `devtools::test()`).
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have added a news item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `future` parameter to `forecast_opts()` to control Rt handling during the forecast period.

* **Deprecations**
  * `rt_opts(future = ...)` is now deprecated; use `forecast_opts(future = ...)` instead. Existing code remains functional with a deprecation warning.

* **Documentation**
  * Updated documentation and examples to reflect the relocated parameter.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->