### PR TITLE
refactoring Stan code for efficiency [WIP]

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,7 @@ The function interface remains unchanged.
 
 ## Model changes
 
+- Refactored Stan code for efficiency (@bob-carpenter, #1273). 
 - MCMC runs are now initialised with parameter values drawn from a distribution that approximates their prior distributions.
 - Added an option to compute growth rates using an estimator by Parag et al. (2022) based on total infectiousness rather than new infections, see `growth_method` argument in rt_opts().
 - Added support for fitting the susceptible population size.

--- a/inst/stan/functions/convolve.stan
+++ b/inst/stan/functions/convolve.stan
@@ -72,11 +72,17 @@ vector convolve_with_rev_pmf(vector x, vector y, int len) {
   }
 
   vector[len] z;
-  int ub = max(len, xlen);
-  for (s in 1:ub) {
+
+  for (s in 1:xlen) {
     array[4] int indices = calc_conv_indices_xlen(s, xlen, ylen);
     z[s] = dot_product(x[indices[1]:indices[2]], y[indices[3]:indices[4]]);
   }
+
+  for (s in (xlen + 1):len) {  // zero iterations unless len > xlen
+    array[4] int indices = calc_conv_indices_len(s, xlen, ylen);
+    z[s] = dot_product(x[indices[1]:indices[2]], y[indices[3]:indices[4]]);
+  }
+
   return z;
 }
 

--- a/inst/stan/functions/convolve.stan
+++ b/inst/stan/functions/convolve.stan
@@ -62,7 +62,6 @@ array[] int calc_conv_indices_len(int s, int xlen, int ylen) {
 vector convolve_with_rev_pmf(vector x, vector y, int len) {
   int xlen = num_elements(x);
   int ylen = num_elements(y);
-  vector[len] z;
 
   if (xlen + ylen - 1 < len) {
     reject("convolve_with_rev_pmf: len is longer than x and y convolved");
@@ -72,18 +71,12 @@ vector convolve_with_rev_pmf(vector x, vector y, int len) {
     reject("convolve_with_rev_pmf: len is shorter than x");
   }
 
-  for (s in 1:xlen) {
+  vector[len] z;
+  int ub = max(len, xlen);
+  for (s in 1:ub) {
     array[4] int indices = calc_conv_indices_xlen(s, xlen, ylen);
     z[s] = dot_product(x[indices[1]:indices[2]], y[indices[3]:indices[4]]);
   }
-
-  if (len > xlen) {
-    for (s in (xlen + 1):len) {
-      array[4] int indices = calc_conv_indices_len(s, xlen, ylen);
-      z[s] = dot_product(x[indices[1]:indices[2]], y[indices[3]:indices[4]]);
-    }
-  }
-
   return z;
 }
 

--- a/inst/stan/functions/gaussian_process.stan
+++ b/inst/stan/functions/gaussian_process.stan
@@ -33,7 +33,7 @@ vector diagSPD_EQ(real alpha, real rho, real L, int M) {
  * @param M Number of basis functions
  * @return Linearly spaced M-vector
  */
-vector matern_indices(int M, int L) {
+vector matern_indices(int M, real L) {
   real factor = pi() / (2 * L);
   return square(linspaced_vector(M, factor, factor * M));
 }
@@ -66,7 +66,7 @@ vector diagSPD_Matern12(real alpha, real rho, real L, int M) {
   * @ingroup estimates_smoothing
   */
 vector diagSPD_Matern32(real alpha, real rho, real L, int M) {
-  real factor1 = 2 * alpha * (sqrt(3) / rho)^1.5;
+  real factor = 2 * alpha * (sqrt(3) / rho)^1.5;
   vector[M] denom = 3 / square(rho) + matern_indices(M, L);
   return factor ./ denom;
 }
@@ -83,7 +83,6 @@ vector diagSPD_Matern32(real alpha, real rho, real L, int M) {
   * @ingroup estimates_smoothing
   */
 vector diagSPD_Matern52(real alpha, real rho, real L, int M) {
-  vector[M] indices = linspaced_vector(M, 1, M);
   real factor = 16 * pow(sqrt(5) / rho, 5);
   vector[M] denom = 3 * pow(5 / square(rho) + matern_indices(M, L), 3);
   return alpha * sqrt(factor ./ denom);


### PR DESCRIPTION
# Work in Progress:  do not merge

I am creating this intermediate PR to see if the EpiNow2 devs want this kind of PR and to ask what kind of testing you want before proceeding to refactor the rest of the code base for efficiency.  

## Description

This PR closes #1273

## Initial submission checklist

<!-- This is for guidance only - please feel free to ignore any lines that don't apply -->

- [x] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have tested my changes locally (using `devtools::test()` and `devtools::check()`).
- [ ] I have added or updated unit tests where necessary.
- [x] I have updated the documentation if required and rebuilt docs if yes (using `devtools::document()`).
- [x] I have followed the established coding standards (and checked using `lintr::lint_package()`).
- [x] I have added a news item linked to this PR.

I'm not an R developer.  I installed `devtools::test()`, but it's failing with an error I don't understand that looks like it's Stan related as it mentions a Stan signature.  I made sure that all of my Stan changes compile in Stan, so I'm not sure where it's coming from or how to track this down.   I'll append the error dump below.

I don't know what you're expecting from the linter run.  The linter dumps out dozens of pages of lint errors when I run it in R on files I haven't touched.  Is there a way to see if the current PR introduced new errors?

## After the initial Pull Request 

- [ ] I have reviewed Checks for this PR and addressed any issues as far as I am able.


## ERROR I'M GETTING WITH `devtools::test()`

```bash
> devtools::test()
ℹ Testing EpiNow2
Error in `(function (command = NULL, args = character(), error_on_status = TRUE, …`:
! System command 'R' failed
---
Exit status: 1
Stdout & stderr (last 10 lines, see `$stderr` for more):
(int, real, real)
Available signatures:
(data int, data real, data real) => vector
  The second argument must be data-only. (Local variables are assumed to
  depend on parameters; same goes for function inputs unless they are marked
  with the keyword 'data'.)
Calls: <Anonymous> -> sapply -> lapply -> FUN -> <Anonymous>
Execution halted
ERROR: configuration failed for package ‘EpiNow2’
* removing ‘/private/var/folders/8f/5nrkg18127x2b8rq18tshp5r0000gr/T/RtmpazDR3K/devtools_install_128b95e5bd56/EpiNow2’
---
Type .Last.error to see the more details
> .Last.error
<system_command_status_error/rlib_error_3_0/rlib_error/error>
Error in `(function (command = NULL, args = character(), error_on_status = TRUE, …`:
! System command 'R' failed
---
Exit status: 1
Stdout & stderr (last 10 lines, see `$stderr` for more):
(int, real, real)
Available signatures:
(data int, data real, data real) => vector
  The second argument must be data-only. (Local variables are assumed to
  depend on parameters; same goes for function inputs unless they are marked
  with the keyword 'data'.)
Calls: <Anonymous> -> sapply -> lapply -> FUN -> <Anonymous>
Execution halted
ERROR: configuration failed for package ‘EpiNow2’
* removing ‘/private/var/folders/8f/5nrkg18127x2b8rq18tshp5r0000gr/T/RtmpazDR3K/devtools_install_128b95e5bd56/EpiNow2’
---
Backtrace:
 1. devtools::test()
 2. testthat::test_local(pkg$path, filter = filter, stop_on_failure = stop_on_failure, …
 3. testthat::test_dir(test_path, package = package, reporter = reporter, ..., …
 4. testthat:::test_files(test_dir = path, test_paths = test_paths, test_package = package, …
 5. testthat:::test_files_serial(test_dir = test_dir, test_package = test_package, …
 6. testthat:::test_files_setup_env(test_package, test_dir, load_package, env)
 7. pkgload::load_all(test_dir, export_all = args[["export_all"]], …
 8. pkgbuild::compile_dll(path, quiet = quiet, debug = debug)
 9. pkgbuild:::withr_with_makevars(compiler_flags(debug), { …
10. pkgbuild:::withr_with_envvar(c(R_MAKEVARS_USER = makevars_file), { …
11. base::force(code)
12. base::force(code)
13. pkgbuild:::withr_with_envvar(c(DEBUG = "true"), build())
14. base::force(code)
15. pkgbuild::build()
16. pkgbuild:::install_min(path, dest = install_dir, components = "libs", args = if (needs_clean(path)) "--preclean", …
17. pkgbuild::rcmd_build_tools("INSTALL", c(path, paste("--library=", dest, …
18. pkgbuild::with_build_tools({ …
19. base::withCallingHandlers(callr::rcmd_safe(..., env = env, spinner = FALSE, …
20. callr::rcmd_safe(..., env = env, spinner = FALSE, show = FALSE, …
21. callr:::run_r(options)
22. base::with(options, with_envvar(env, do.call(processx::run, c(list(bin, …
23. base::with.default(options, with_envvar(env, do.call(processx::run, …
24. base::eval(substitute(expr), data, enclos = parent.frame())
25. base::eval(substitute(expr), data, enclos = parent.frame())
26. callr:::with_envvar(env, do.call(processx::run, c(list(bin, args = real_cmdargs, …
27. base::force(code)
28. base::do.call(processx::run, c(list(bin, args = real_cmdargs, stdout_line_callback = real_callback(stdout), …
29. (function (command = NULL, args = character(), error_on_status = TRUE, …
30. base::throw(new_process_error(res, call = sys.call(), echo = echo, …
31. | base::signalCondition(cond)
32. (function (e) …
33. asNamespace("callr")$err$throw(e)
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Exported new Matern indices helper function for public use

* **Refactor**
  - Optimised Gaussian Process spectral density computations for Matern kernels
  - Streamlined periodic spectral density calculations
  - Simplified noise setup process

* **Bug Fixes**
  - Improved error messages for unsupported Matern parameter values

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->