### PR TITLE
Update vignettes to use current API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@ The function interface remains unchanged.
 
 ## Documentation
 
+- Updated vignettes to use the current API, removing deprecated argument usage (`output = "estimated_reported_cases"`, `$plots$R`) and replacing with `estimates_by_report_date()` and `plot()`. Also removed log and timing output that changes between runs.
 - Added guidelines for AI-assisted contributions to the CONTRIBUTING guide, including transparency requirements, contributor responsibilities, and AI-assisted code reviews.
 - Added a comprehensive prior choice and specification guide vignette covering all three main modelling functions with practical guidance on when and how to modify priors.
 - Fixed broken `@seealso` links in roxygen2 documentation by converting plain text function references to proper link syntax.

--- a/vignettes/EpiNow2.Rmd
+++ b/vignettes/EpiNow2.Rmd
@@ -136,9 +136,7 @@ estimates <- epinow(
   verbose = interactive()
 )
 names(estimates)
-#> [1] "estimates"                "estimated_reported_cases"
-#> [3] "summary"                  "plots"                   
-#> [5] "timing"
+#> [1] "fit"          "args"         "observations" "timing"
 ```
 
 Both summary measures and posterior samples are returned for all parameters in an easily explored format which can be accessed using `summary`. The default is to return a summary table of estimates for key parameters at the latest date partially supported by data. 
@@ -183,11 +181,11 @@ head(summary(estimates, type = "parameters", params = "R"))
 #> 6: 1.936513 1.970944 2.012702 2.051563 2.153084
 ```
 
-Reported cases are returned in a separate data frame in order to streamline the reporting of forecasts and for model evaluation.
+Reported cases are returned in a separate data frame in order to streamline the reporting of forecasts and for model evaluation using `estimates_by_report_date()`.
 
 
 ``` r
-head(summary(estimates, output = "estimated_reported_cases"))
+head(estimates_by_report_date(estimates))
 #>          date   type median     mean        sd lower_90 lower_50 lower_20
 #>        <Date> <char>  <num>    <num>     <num>    <num>    <num>    <num>
 #> 1: 2020-02-22  gp_rt     36  36.2210  9.597511    22.00       30       33
@@ -259,19 +257,6 @@ estimates <- regional_epinow(
   gp = NULL,
   stan = stan_opts(cores = 4, warmup = 250, samples = 1000)
 )
-#> INFO [2025-06-01 00:26:04] Producing following optional outputs: regions, summary, samples, plots, latest
-#> INFO [2025-06-01 00:26:04] Reporting estimates using data up to: 2020-04-21
-#> INFO [2025-06-01 00:26:04] No target directory specified so returning output
-#> INFO [2025-06-01 00:26:04] Producing estimates for: testland, realland
-#> INFO [2025-06-01 00:26:04] Regions excluded: none
-#> INFO [2025-06-01 00:26:24] Completed estimates for: testland
-#> INFO [2025-06-01 00:26:44] Completed estimates for: realland
-#> INFO [2025-06-01 00:26:44] Completed regional estimates
-#> INFO [2025-06-01 00:26:44] Regions with estimates: 2
-#> INFO [2025-06-01 00:26:44] Regions with runtime errors: 0
-#> INFO [2025-06-01 00:26:44] Producing summary
-#> INFO [2025-06-01 00:26:44] No summary directory specified so returning summary output
-#> INFO [2025-06-01 00:26:45] No target directory specified so returning timings
 ```
 
 Results from each region are stored in a `regional` list with across region summary measures and plots stored in a `summary` list. All results can be set to be internally saved by setting the `target_folder` and `summary_dir` arguments. Each region can be estimated in parallel using the `{future}` package (when in most scenarios `cores` should be set to 1). For routine use each MCMC chain can also be run in parallel (with `future` = `TRUE`) with a time out (`max_execution_time`) allowing for partial results to be returned if a subset of chains is running longer than expected. See the documentation for the [`{future}`](https://future.futureverse.org/) package for details on nested futures.

--- a/vignettes/epinow.Rmd
+++ b/vignettes/epinow.Rmd
@@ -45,17 +45,11 @@ We can then run the `epinow()` function with the same arguments as `estimate_inf
 
 ``` r
 res <- epinow(reported_cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
   rt = rt_opts(prior = rt_prior)
 )
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2 logs to the console and:
-#> '/tmp/RtmpTIgwPA/regional-epinow/2020-04-21.log'.
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2.epinow logs to the console and:
-#> '/tmp/RtmpTIgwPA/epinow/2020-04-21.log'.
-res$plots$R
+plot(res)
 ```
 
 ![plot of chunk epinow](epinow-epinow-1.png)
@@ -85,28 +79,10 @@ To then run this on multiple regions using the default options above, we could u
 ``` r
 region_rt <- regional_epinow(
   data = cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
   rt = rt_opts(prior = rt_prior),
 )
-#> INFO [2025-02-04 19:51:23] Producing following optional outputs: regions, summary, samples, plots, latest
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2 logs to the console and:
-#> '/tmp/RtmpTIgwPA/regional-epinow/2020-04-21.log'.
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2.epinow logs to: '/tmp/RtmpTIgwPA/epinow/2020-04-21.log'.
-#> INFO [2025-02-04 19:51:23] Reporting estimates using data up to: 2020-04-21
-#> INFO [2025-02-04 19:51:23] No target directory specified so returning output
-#> INFO [2025-02-04 19:51:23] Producing estimates for: testland, realland
-#> INFO [2025-02-04 19:51:23] Regions excluded: none
-#> INFO [2025-02-04 19:54:18] Completed estimates for: testland
-#> INFO [2025-02-04 19:55:24] Completed estimates for: realland
-#> INFO [2025-02-04 19:55:24] Completed regional estimates
-#> INFO [2025-02-04 19:55:24] Regions with estimates: 2
-#> INFO [2025-02-04 19:55:24] Regions with runtime errors: 0
-#> INFO [2025-02-04 19:55:24] Producing summary
-#> INFO [2025-02-04 19:55:24] No summary directory specified so returning summary output
-#> INFO [2025-02-04 19:55:24] No target directory specified so returning timings
 ## summary
 region_rt$summary$summarised_results$table
 #>      Region New infections per day Expected change in reports
@@ -136,28 +112,10 @@ gp <- modifyList(gp, list(realland = NULL), keep.null = TRUE)
 rt <- opts_list(rt_opts(), cases, realland = rt_opts(rw = 7))
 region_separate_rt <- regional_epinow(
   data = cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
   rt = rt, gp = gp,
 )
-#> INFO [2025-02-04 19:55:25] Producing following optional outputs: regions, summary, samples, plots, latest
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2 logs to the console and:
-#> '/tmp/RtmpTIgwPA/regional-epinow/2020-04-21.log'.
-#> Logging threshold set at INFO for the name logger
-#> Writing EpiNow2.epinow logs to: '/tmp/RtmpTIgwPA/epinow/2020-04-21.log'.
-#> INFO [2025-02-04 19:55:25] Reporting estimates using data up to: 2020-04-21
-#> INFO [2025-02-04 19:55:25] No target directory specified so returning output
-#> INFO [2025-02-04 19:55:25] Producing estimates for: testland, realland
-#> INFO [2025-02-04 19:55:25] Regions excluded: none
-#> INFO [2025-02-04 19:56:30] Completed estimates for: testland
-#> INFO [2025-02-04 19:56:59] Completed estimates for: realland
-#> INFO [2025-02-04 19:56:59] Completed regional estimates
-#> INFO [2025-02-04 19:56:59] Regions with estimates: 2
-#> INFO [2025-02-04 19:56:59] Regions with runtime errors: 0
-#> INFO [2025-02-04 19:56:59] Producing summary
-#> INFO [2025-02-04 19:56:59] No summary directory specified so returning summary output
-#> INFO [2025-02-04 19:57:00] No target directory specified so returning timings
 ## summary
 region_separate_rt$summary$summarised_results$table
 #>      Region New infections per day Expected change in reports


### PR DESCRIPTION
This PR closes #1229.

## Summary

- Updated `EpiNow2.Rmd` vignette to use the new return structure (`fit`, `args`, `observations`, `timing` instead of the old `estimates`, `estimated_reported_cases`, `summary`, `plots`)
- Replaced deprecated `summary(estimates, output = "estimated_reported_cases")` with `estimates_by_report_date(estimates)`
- Updated `epinow.Rmd` vignette to use `gt_opts()` instead of `generation_time_opts()` and `plot()` instead of `res$plots$R`
- Removed log and timing output from vignettes that changes between runs (timestamps, temp folder paths)

## Test plan

- [ ] Check that vignettes build successfully
- [ ] Verify the code examples still work with the current API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Documentation**
* Updated all vignettes and examples to reflect changes to the epinow() function return structure and data access patterns
* Modified how reported cases estimation data is accessed from results
* Renamed generation time options function for consistency
* Eliminated verbose logging and timing output from standard application runs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->