### PR TITLE
Update vignettes to use current API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,6 +81,7 @@ The function interface remains unchanged.
 
 ## Documentation
 
+- Updated vignettes to use the current API (`gt_opts()` instead of `generation_time_opts()`, `plot()` instead of `$plots$R`, `estimates_by_report_date()` instead of deprecated `output` argument) and disabled logging output with `logs = NULL` to prevent output changing between runs.
 - Added guidelines for AI-assisted contributions to the CONTRIBUTING guide, including transparency requirements, contributor responsibilities, and AI-assisted code reviews.
 - Added a comprehensive prior choice and specification guide vignette covering all three main modelling functions with practical guidance on when and how to modify priors.
 - Fixed broken `@seealso` links in roxygen2 documentation by converting plain text function references to proper link syntax.

--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -113,10 +113,10 @@ Summarised parameter estimates can also easily be returned, either filtered for 
 head(summary(estimates, type = "parameters", params = "R"))
 ```
 
-Reported cases are returned in a separate data frame in order to streamline the reporting of forecasts and for model evaluation.
+Reported cases are returned in a separate data frame in order to streamline the reporting of forecasts and for model evaluation using `estimates_by_report_date()`.
 
 ```{r}
-head(summary(estimates, output = "estimated_reported_cases"))
+head(estimates_by_report_date(estimates))
 ```
 
 A range of plots are returned (with the single summary plot shown below). These plots can also be generated using the following `plot` method.
@@ -157,7 +157,8 @@ estimates <- regional_epinow(
   rt = rt_opts(prior = LogNormal(mean = 2, sd = 0.2), rw = 7),
   obs = obs,
   gp = NULL,
-  stan = stan_opts(cores = 4, warmup = 250, samples = 1000)
+  stan = stan_opts(cores = 4, warmup = 250, samples = 1000),
+  logs = NULL
 )
 ```
 

--- a/vignettes/epinow.Rmd.orig
+++ b/vignettes/epinow.Rmd.orig
@@ -47,15 +47,15 @@ We can then run the `epinow()` function with the same arguments as `estimate_inf
 
 ```{r epinow}
 res <- epinow(reported_cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
-  rt = rt_opts(prior = rt_prior)
+  rt = rt_opts(prior = rt_prior),
+  logs = NULL
 )
-res$plots$R
+plot(res)
 ```
 
-The initial messages here indicate where log files can be found.
-If you want summarised results and plots to be written out where they can be accessed later you can use the `target_folder` argument.
+By default, logging messages are printed to the console indicating the progress of the model fitting and where log files can be found. Here we have set `logs = NULL` to suppress these messages. If you want summarised results and plots to be written out where they can be accessed later you can use the `target_folder` argument.
 
 # Running the model simultaneously on multiple regions
 
@@ -77,9 +77,10 @@ To then run this on multiple regions using the default options above, we could u
 ```{r regional_epinow, fig.width = 8}
 region_rt <- regional_epinow(
   data = cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
   rt = rt_opts(prior = rt_prior),
+  logs = NULL
 )
 ## summary
 region_rt$summary$summarised_results$table
@@ -95,9 +96,10 @@ gp <- modifyList(gp, list(realland = NULL), keep.null = TRUE)
 rt <- opts_list(rt_opts(), cases, realland = rt_opts(rw = 7))
 region_separate_rt <- regional_epinow(
   data = cases,
-  generation_time = generation_time_opts(example_generation_time),
+  generation_time = gt_opts(example_generation_time),
   delays = delay_opts(delay),
   rt = rt, gp = gp,
+  logs = NULL
 )
 ## summary
 region_separate_rt$summary$summarised_results$table


### PR DESCRIPTION
This PR closes #1229.

## Summary

- Updated `EpiNow2.Rmd.orig` vignette:
  - Replaced deprecated `summary(estimates, output = "estimated_reported_cases")` with `estimates_by_report_date(estimates)`
  - Added `logs = NULL` to `regional_epinow()` call to suppress log output

- Updated `epinow.Rmd.orig` vignette:
  - Changed `generation_time_opts()` to `gt_opts()` (3 occurrences)
  - Changed `res$plots$R` to `plot(res)`
  - Added `logs = NULL` to all `epinow()` and `regional_epinow()` calls
  - Updated explanatory text about logging

## Test plan

- [ ] Render the vignettes to verify they build successfully
- [ ] Verify the code examples still work with the current API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples and vignettes to align with current API conventions and updated function calls.
  * Documentation enhanced with improved logging configuration guidance to ensure consistent results across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->