### PR TITLE
Install scoringutils for vignette rendering

### DIFF
--- a/.github/workflows/render-estimate_infections_workflow.yaml
+++ b/.github/workflows/render-estimate_infections_workflow.yaml
@@ -32,7 +32,9 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           dependencies: NA
-          extra-packages: local::.
+          extra-packages: |
+            local::.
+            any::scoringutils
 
       - name: Render vignette
         run: |


### PR DESCRIPTION
This PR addresses https://github.com/epiforecasts/EpiNow2/pull/1286#issuecomment-3840342718

## Summary

The `estimate_infections_workflow` vignette now includes a section on using scoringutils for forecast evaluation. The render workflow needs to install scoringutils to render this section correctly.

## Test plan

- [ ] Re-run the vignette render workflow after merging #1286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
* Updated workflow dependencies to include additional statistical analysis packages, enhancing support for infection estimate processing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->