### PR TITLE
Use get_predictions() instead of internal estimates_by_report_date() in vignette

### DIFF
--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -113,10 +113,10 @@ Summarised parameter estimates can also easily be returned, either filtered for 
 head(summary(estimates, type = "parameters", params = "R"))
 ```
 
-Reported cases are returned in a separate data frame in order to streamline the reporting of forecasts and for model evaluation using `estimates_by_report_date()`.
+Reported cases can be extracted using `get_predictions()` which returns summarised estimates by default.
 
 ```{r}
-head(estimates_by_report_date(estimates))
+head(get_predictions(estimates))
 ```
 
 A range of plots are returned (with the single summary plot shown below). These plots can also be generated using the following `plot` method.


### PR DESCRIPTION
This PR addresses https://github.com/epiforecasts/EpiNow2/pull/1287#discussion_r2758276099

## Summary

The EpiNow2 vignette was calling `estimates_by_report_date()` which is an internal function. This replaces it with the exported `get_predictions()` function.

## Notes on the `parameter` column

The summary output now includes a `parameter` column alongside `variable`. This is intentional:

- For time-varying parameters (R, infections, etc.): `variable` and `parameter` are identical
- For grouped parameters (delay_params, params): `variable` is the category while `parameter` is the specific name (e.g., `variable = "delay_params"`, `parameter = "incubation_meanlog"`)

This allows proper grouping in summary statistics while preserving detailed parameter names.

## Test plan

- [ ] Vignette renders successfully after this change is merged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `get_predictions()` function now available to extract and retrieve summarised estimates for reported cases by default.

* **Documentation**
  * Updated vignette documentation with revised explanatory text and updated code examples demonstrating the new approach for obtaining predictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->