### PR TITLE
Add signposting to faster model configurations in getting started vignette

### DIFF
--- a/vignettes/EpiNow2.Rmd
+++ b/vignettes/EpiNow2.Rmd
@@ -145,7 +145,7 @@ The default model uses a Gaussian process to estimate time-varying transmission,
 - Use variational inference for fast but unreliable approximate results (`stan = stan_opts(method = "vb")`).
 - Reduce the accuracy of the Gaussian process approximation (see `?gp_opts`).
 
-For a comparison of model formulations and their trade-offs, see the [estimate_infections_options](estimate_infections_options.html) vignette.
+For examples of different model configurations, see the [estimate_infections_options](estimate_infections_options.html) vignette.
 
 Both summary measures and posterior samples are returned for all parameters in an easily explored format which can be accessed using `summary`. The default is to return a summary table of estimates for key parameters at the latest date partially supported by data. 
 

--- a/vignettes/EpiNow2.Rmd.orig
+++ b/vignettes/EpiNow2.Rmd.orig
@@ -107,7 +107,7 @@ The default model uses a Gaussian process to estimate time-varying transmission,
 - Use variational inference for fast but unreliable approximate results (`stan = stan_opts(method = "vb")`).
 - Reduce the accuracy of the Gaussian process approximation (see `?gp_opts`).
 
-For a comparison of model formulations and their trade-offs, see the [estimate_infections_options](estimate_infections_options.html) vignette.
+For examples of different model configurations, see the [estimate_infections_options](estimate_infections_options.html) vignette.
 
 Both summary measures and posterior samples are returned for all parameters in an easily explored format which can be accessed using `summary`. The default is to return a summary table of estimates for key parameters at the latest date partially supported by data. 
 


### PR DESCRIPTION
## Summary

- Adds signposting after the first `epinow()` example to explain that the default Gaussian process model can be slow
- Points users to faster alternatives: weekly random walk, variational inference, and reduced GP accuracy
- Links to the `estimate_infections_options` vignette for detailed comparison

This PR closes #730.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Updated vignette with enhanced guidance on modelling options for the estimate_infections model.
- Added details on speed and accuracy trade-offs, including weekly random walk, variational inference, and Gaussian process optimisation alternatives.
- Included cross-references to comparative documentation for model formulations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->